### PR TITLE
[BM-110] 프로필 수정 페이지 레이아웃 구현

### DIFF
--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -2,36 +2,85 @@ import {
   Avatar,
   Box,
   Center,
+  Circle,
   Flex,
   Input,
   InputGroup,
   InputRightElement,
+  Text,
 } from '@chakra-ui/react';
 import { EditIcon } from '@chakra-ui/icons';
+import Header from '@common/header';
+import GoBackIcon from '@common/Header/GoBackIcon';
 
 const ProfileEdit = () => {
-  // TODO: header 공통 컴포넌트 구현되면 추가 해주기
   return (
-    <>
-      <Box textAlign="center">TODO 공통 헤더!</Box>
-      <Center width="100%" marginTop="48px">
+    <Flex flexDirection="column" width="100%" height="100%">
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={
+          <Text
+            fontFamily="Roboto"
+            fontSize="20px"
+            fontWeight="bold"
+            lineHeight="23px"
+            fontStyle="normal"
+            color="#2E2E2E"
+          >
+            프로필수정
+          </Text>
+        }
+      ></Header>
+      <Flex width="100%" height="100%" marginTop="48px">
         <Flex width="100%" direction="column" alignItems="center" gap="48px">
-          <Avatar
-            name="Christian Nwamba"
-            size="2xl"
-            src="https://bit.ly/code-beast"
-          />
-          <Flex width="100%" paddingRight="15px" paddingLeft="15px">
+          <Circle border="2px solid #FF4370">
+            <Avatar
+              name="Christian Nwamba"
+              size="2xl"
+              src="https://bit.ly/code-beast"
+            />
+          </Circle>
+          <Flex
+            flexGrow="1"
+            width="100%"
+            paddingRight="19px"
+            paddingLeft="19px"
+            height="70%"
+          >
             <InputGroup size="md">
-              <Input variant="flushed" size="lg" placeholder="물안경" />
-              <InputRightElement width="24px" height="24px">
-                <EditIcon alignSelf="center" />
+              <Input
+                variant="flushed"
+                size="lg"
+                placeholder="물안경"
+                border="0.7px solid #BFBFBF"
+                borderRadius="10px"
+                paddingLeft="23px"
+              />
+              <InputRightElement paddingRight="16px">
+                <EditIcon width="22px" height="22px" alignSelf="center" />
               </InputRightElement>
             </InputGroup>
           </Flex>
+          <Center
+            flexShrink="0"
+            justifySelf="flex-end"
+            width="100%"
+            height="57px"
+            backgroundColor="#FF4370"
+          >
+            <Text
+              fontStyle="Roboto"
+              fontSize="17px"
+              fontWeight="400px"
+              lineHeight="20px"
+              color="white"
+            >
+              완료
+            </Text>
+          </Center>
         </Flex>
-      </Center>
-    </>
+      </Flex>
+    </Flex>
   );
 };
 

--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -1,0 +1,38 @@
+import {
+  Avatar,
+  Box,
+  Center,
+  Flex,
+  Input,
+  InputGroup,
+  InputRightElement,
+} from '@chakra-ui/react';
+import { EditIcon } from '@chakra-ui/icons';
+
+const ProfileEdit = () => {
+  // TODO: header 공통 컴포넌트 구현되면 추가 해주기
+  return (
+    <>
+      <Box textAlign="center">TODO 공통 헤더!</Box>
+      <Center width="100%" marginTop="48px">
+        <Flex width="100%" direction="column" alignItems="center" gap="48px">
+          <Avatar
+            name="Christian Nwamba"
+            size="2xl"
+            src="https://bit.ly/code-beast"
+          />
+          <Flex width="100%" paddingRight="15px" paddingLeft="15px">
+            <InputGroup size="md">
+              <Input variant="flushed" size="lg" placeholder="물안경" />
+              <InputRightElement width="24px" height="24px">
+                <EditIcon alignSelf="center" />
+              </InputRightElement>
+            </InputGroup>
+          </Flex>
+        </Flex>
+      </Center>
+    </>
+  );
+};
+
+export default ProfileEdit;

--- a/components/common/header/goBackIcon.tsx
+++ b/components/common/header/goBackIcon.tsx
@@ -1,7 +1,10 @@
 import { ChevronLeftIcon } from '@chakra-ui/icons';
+import { useRouter } from 'next/router';
 
 const GoBackIcon = () => {
-  return <ChevronLeftIcon boxSize="8" />;
+  const router = useRouter();
+
+  return <ChevronLeftIcon boxSize="8" onClick={() => router.back()} />;
 };
 
 export default GoBackIcon;

--- a/components/common/header/goBackIcon.tsx
+++ b/components/common/header/goBackIcon.tsx
@@ -1,0 +1,7 @@
+import { ChevronLeftIcon } from '@chakra-ui/icons';
+
+const GoBackIcon = () => {
+  return <ChevronLeftIcon boxSize="8" />;
+};
+
+export default GoBackIcon;

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,7 +1,28 @@
-import type { NextPage } from 'next';
+import { ChevronLeftIcon, HamburgerIcon } from '@chakra-ui/icons';
+import { Center, Flex, Text } from '@chakra-ui/react';
 
-const Header: NextPage = () => {
-  return <div>Header</div>;
+const Header = ({
+  left,
+  middle,
+  right,
+}: {
+  left?: string;
+  middle?: string;
+  right?: string;
+}) => {
+  return (
+    <Flex padding="10px" justifyContent="space-between" width="100%">
+      <Flex alignItems="center" flex="1">
+        <ChevronLeftIcon boxSize="8" />
+      </Flex>
+      <Center alignItems="center" flex="1">
+        <Text>bidmarket</Text>
+      </Center>
+      <Flex justifyContent="flex-end" alignItems="center" flex="1">
+        <HamburgerIcon boxSize="6" />
+      </Flex>
+    </Flex>
+  );
 };
 
 export default Header;

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,25 +1,22 @@
-import { ChevronLeftIcon, HamburgerIcon } from '@chakra-ui/icons';
-import { Center, Flex, Text } from '@chakra-ui/react';
+import { Center, Flex } from '@chakra-ui/react';
 
-const Header = ({
-  left,
-  middle,
-  right,
-}: {
-  left?: string;
-  middle?: string;
-  right?: string;
-}) => {
+interface HeaderProp {
+  left?: React.ReactNode;
+  middle?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+const Header = ({ left, middle, right }: HeaderProp) => {
   return (
     <Flex padding="10px" justifyContent="space-between" width="100%">
       <Flex alignItems="center" flex="1">
-        <ChevronLeftIcon boxSize="8" />
+        {left}
       </Flex>
       <Center alignItems="center" flex="1">
-        <Text>bidmarket</Text>
+        {middle}
       </Center>
       <Flex justifyContent="flex-end" alignItems="center" flex="1">
-        <HamburgerIcon boxSize="6" />
+        {right}
       </Flex>
     </Flex>
   );

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,22 +1,22 @@
 import { Center, Flex } from '@chakra-ui/react';
 
 interface HeaderProp {
-  left?: React.ReactNode;
-  middle?: React.ReactNode;
-  right?: React.ReactNode;
+  leftContent?: React.ReactNode;
+  middleContent?: React.ReactNode;
+  rightContent?: React.ReactNode;
 }
 
-const Header = ({ left, middle, right }: HeaderProp) => {
+const Header = ({ leftContent, middleContent, rightContent }: HeaderProp) => {
   return (
     <Flex padding="10px" justifyContent="space-between" width="100%">
       <Flex alignItems="center" flex="1">
-        {left}
+        {leftContent}
       </Flex>
       <Center alignItems="center" flex="1">
-        {middle}
+        {middleContent}
       </Center>
       <Flex justifyContent="flex-end" alignItems="center" flex="1">
-        {right}
+        {rightContent}
       </Flex>
     </Flex>
   );

--- a/components/common/header/sideBar.tsx
+++ b/components/common/header/sideBar.tsx
@@ -1,0 +1,7 @@
+import { HamburgerIcon } from '@chakra-ui/icons';
+
+const SideBar = () => {
+  return <HamburgerIcon boxSize="6" />;
+};
+
+export default SideBar;

--- a/components/common/header/sideBar.tsx
+++ b/components/common/header/sideBar.tsx
@@ -1,7 +1,31 @@
 import { HamburgerIcon } from '@chakra-ui/icons';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  useDisclosure,
+} from '@chakra-ui/react';
 
 const SideBar = () => {
-  return <HamburgerIcon boxSize="6" />;
-};
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
+  // TODO 전역 상태의 회원 정보 가지고 있기
+  return (
+    <>
+      <HamburgerIcon boxSize="6" onClick={onOpen} />
+      <Drawer placement="right" onClose={onClose} isOpen={isOpen}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader borderBottomWidth="1px">회원이름</DrawerHeader>
+          <DrawerBody>
+            <p>회원 정보</p>
+            <p>로그아웃</p>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};
 export default SideBar;

--- a/components/common/seo/index.tsx
+++ b/components/common/seo/index.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+interface SeoProps {
+  title: string;
+}
+
+const Seo = ({ title }: SeoProps) => {
+  return (
+    <Head>
+      <title>{title} | Bidmarket</title>
+    </Head>
+  );
+};
+
+export default Seo;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,7 +1,10 @@
+import { Text } from '@chakra-ui/react';
+import Header from '@common/header';
+import GoBackIcon from '@common/header/goBackIcon';
 import type { NextPage } from 'next';
 
 const Login: NextPage = () => {
-  return <div>Login</div>;
+  return <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />;
 };
 
 export default Login;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,10 +1,16 @@
 import { Text } from '@chakra-ui/react';
 import Header from '@common/header';
 import GoBackIcon from '@common/header/goBackIcon';
+import Seo from '@common/seo';
 import type { NextPage } from 'next';
 
 const Login: NextPage = () => {
-  return <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />;
+  return (
+    <>
+      <Seo title="로그인" />
+      <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />
+    </>
+  );
 };
 
 export default Login;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -8,7 +8,10 @@ const Login: NextPage = () => {
   return (
     <>
       <Seo title="로그인" />
-      <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<Text>비드마켓</Text>}
+      />
     </>
   );
 };

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@chakra-ui/react';
-import Header from '@common/header';
-import GoBackIcon from '@common/header/goBackIcon';
-import Seo from '@common/seo';
+import Header from '@common/Header';
+import GoBackIcon from '@common/Header/GoBackIcon';
+import Seo from '@common/Seo';
 import type { NextPage } from 'next';
 
 const Login: NextPage = () => {

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -1,7 +1,8 @@
+import ProfileEdit from 'components/ProfileEdit';
 import type { NextPage } from 'next';
 
 const Edit: NextPage = () => {
-  return <div>Edit</div>;
+  return <ProfileEdit />;
 };
 
 export default Edit;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
프로필 수정 페이지 레이아웃 구현

# 작업 진행 사항
<img width="368" alt="스크린샷 2022-07-25 오후 11 59 02" src="https://user-images.githubusercontent.com/16220817/180808154-c85561de-a38e-4c6d-b239-d1dcd282f56c.png">
프로필 수정 페이지 레이아웃 구현

# 관련 이슈
<!-- TODO, 테스트 유의, 앞으로 구현해야할 기능 -->
- Header 컴포넌트 구현 완료시 적용해야함.
- 기능 관련 구현 필요.

# 중점적으로 봐줬으면 하는 부분
- 없습니다.