### PR TITLE
[BM-105] Header 컴포넌트 구현

### DIFF
--- a/components/common/header/goBackIcon.tsx
+++ b/components/common/header/goBackIcon.tsx
@@ -1,7 +1,10 @@
 import { ChevronLeftIcon } from '@chakra-ui/icons';
+import { useRouter } from 'next/router';
 
 const GoBackIcon = () => {
-  return <ChevronLeftIcon boxSize="8" />;
+  const router = useRouter();
+
+  return <ChevronLeftIcon boxSize="8" onClick={() => router.back()} />;
 };
 
 export default GoBackIcon;

--- a/components/common/header/goBackIcon.tsx
+++ b/components/common/header/goBackIcon.tsx
@@ -1,0 +1,7 @@
+import { ChevronLeftIcon } from '@chakra-ui/icons';
+
+const GoBackIcon = () => {
+  return <ChevronLeftIcon boxSize="8" />;
+};
+
+export default GoBackIcon;

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,7 +1,28 @@
-import type { NextPage } from 'next';
+import { ChevronLeftIcon, HamburgerIcon } from '@chakra-ui/icons';
+import { Center, Flex, Text } from '@chakra-ui/react';
 
-const Header: NextPage = () => {
-  return <div>Header</div>;
+const Header = ({
+  left,
+  middle,
+  right,
+}: {
+  left?: string;
+  middle?: string;
+  right?: string;
+}) => {
+  return (
+    <Flex padding="10px" justifyContent="space-between" width="100%">
+      <Flex alignItems="center" flex="1">
+        <ChevronLeftIcon boxSize="8" />
+      </Flex>
+      <Center alignItems="center" flex="1">
+        <Text>bidmarket</Text>
+      </Center>
+      <Flex justifyContent="flex-end" alignItems="center" flex="1">
+        <HamburgerIcon boxSize="6" />
+      </Flex>
+    </Flex>
+  );
 };
 
 export default Header;

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,25 +1,22 @@
-import { ChevronLeftIcon, HamburgerIcon } from '@chakra-ui/icons';
-import { Center, Flex, Text } from '@chakra-ui/react';
+import { Center, Flex } from '@chakra-ui/react';
 
-const Header = ({
-  left,
-  middle,
-  right,
-}: {
-  left?: string;
-  middle?: string;
-  right?: string;
-}) => {
+interface HeaderProp {
+  left?: React.ReactNode;
+  middle?: React.ReactNode;
+  right?: React.ReactNode;
+}
+
+const Header = ({ left, middle, right }: HeaderProp) => {
   return (
     <Flex padding="10px" justifyContent="space-between" width="100%">
       <Flex alignItems="center" flex="1">
-        <ChevronLeftIcon boxSize="8" />
+        {left}
       </Flex>
       <Center alignItems="center" flex="1">
-        <Text>bidmarket</Text>
+        {middle}
       </Center>
       <Flex justifyContent="flex-end" alignItems="center" flex="1">
-        <HamburgerIcon boxSize="6" />
+        {right}
       </Flex>
     </Flex>
   );

--- a/components/common/header/index.tsx
+++ b/components/common/header/index.tsx
@@ -1,22 +1,22 @@
 import { Center, Flex } from '@chakra-ui/react';
 
 interface HeaderProp {
-  left?: React.ReactNode;
-  middle?: React.ReactNode;
-  right?: React.ReactNode;
+  leftContent?: React.ReactNode;
+  middleContent?: React.ReactNode;
+  rightContent?: React.ReactNode;
 }
 
-const Header = ({ left, middle, right }: HeaderProp) => {
+const Header = ({ leftContent, middleContent, rightContent }: HeaderProp) => {
   return (
     <Flex padding="10px" justifyContent="space-between" width="100%">
       <Flex alignItems="center" flex="1">
-        {left}
+        {leftContent}
       </Flex>
       <Center alignItems="center" flex="1">
-        {middle}
+        {middleContent}
       </Center>
       <Flex justifyContent="flex-end" alignItems="center" flex="1">
-        {right}
+        {rightContent}
       </Flex>
     </Flex>
   );

--- a/components/common/header/sideBar.tsx
+++ b/components/common/header/sideBar.tsx
@@ -1,0 +1,7 @@
+import { HamburgerIcon } from '@chakra-ui/icons';
+
+const SideBar = () => {
+  return <HamburgerIcon boxSize="6" />;
+};
+
+export default SideBar;

--- a/components/common/header/sideBar.tsx
+++ b/components/common/header/sideBar.tsx
@@ -1,7 +1,31 @@
 import { HamburgerIcon } from '@chakra-ui/icons';
+import {
+  Drawer,
+  DrawerBody,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  useDisclosure,
+} from '@chakra-ui/react';
 
 const SideBar = () => {
-  return <HamburgerIcon boxSize="6" />;
-};
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
+  // TODO 전역 상태의 회원 정보 가지고 있기
+  return (
+    <>
+      <HamburgerIcon boxSize="6" onClick={onOpen} />
+      <Drawer placement="right" onClose={onClose} isOpen={isOpen}>
+        <DrawerOverlay />
+        <DrawerContent>
+          <DrawerHeader borderBottomWidth="1px">회원이름</DrawerHeader>
+          <DrawerBody>
+            <p>회원 정보</p>
+            <p>로그아웃</p>
+          </DrawerBody>
+        </DrawerContent>
+      </Drawer>
+    </>
+  );
+};
 export default SideBar;

--- a/components/common/seo/index.tsx
+++ b/components/common/seo/index.tsx
@@ -1,0 +1,15 @@
+import Head from 'next/head';
+
+interface SeoProps {
+  title: string;
+}
+
+const Seo = ({ title }: SeoProps) => {
+  return (
+    <Head>
+      <title>{title} | Bidmarket</title>
+    </Head>
+  );
+};
+
+export default Seo;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,7 +1,10 @@
+import { Text } from '@chakra-ui/react';
+import Header from '@common/header';
+import GoBackIcon from '@common/header/goBackIcon';
 import type { NextPage } from 'next';
 
 const Login: NextPage = () => {
-  return <div>Login</div>;
+  return <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />;
 };
 
 export default Login;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,10 +1,16 @@
 import { Text } from '@chakra-ui/react';
 import Header from '@common/header';
 import GoBackIcon from '@common/header/goBackIcon';
+import Seo from '@common/seo';
 import type { NextPage } from 'next';
 
 const Login: NextPage = () => {
-  return <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />;
+  return (
+    <>
+      <Seo title="로그인" />
+      <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />
+    </>
+  );
 };
 
 export default Login;

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -8,7 +8,10 @@ const Login: NextPage = () => {
   return (
     <>
       <Seo title="로그인" />
-      <Header left={<GoBackIcon />} middle={<Text>비드마켓</Text>} />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<Text>비드마켓</Text>}
+      />
     </>
   );
 };

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@chakra-ui/react';
-import Header from '@common/header';
-import GoBackIcon from '@common/header/goBackIcon';
-import Seo from '@common/seo';
+import Header from '@common/Header';
+import GoBackIcon from '@common/Header/GoBackIcon';
+import Seo from '@common/Seo';
 import type { NextPage } from 'next';
 
 const Login: NextPage = () => {


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] Header 컴포넌트 구현
   - left, middle, right로 prop을 내려 사용 가능
   - 사용하는 페이지에서 해당 prop에 알맞게 작성하여 사용
- [x] 뒤로가기 컴포넌트
   - Components/common/Header 내부에 작성
   - useRouter 훅을 이용
- [x ]사이드바 컴포넌트
   - Components/common/Header 내부에 작성
   - Drawer를 이용하여 구현
- [x] Seo 컴포넌트
   - Components/Seo 내부에 작성
   - 페이지 탭 제목에 사용

# 작업 진행 사항
<img width="240" alt="스크린샷 2022-07-26 16 42 44" src="https://user-images.githubusercontent.com/75886763/180951478-54fe6571-8c12-4af9-b09d-876bef0b2e77.png">
<img width="240" alt="스크린샷 2022-07-26 16 43 03" src="https://user-images.githubusercontent.com/75886763/180951524-c86e5524-d8a3-4c3c-914b-46661e9baf65.png">
<img width="240" alt="스크린샷 2022-07-26 16 43 21" src="https://user-images.githubusercontent.com/75886763/180951587-49a65874-b5f8-4c49-acba-0efaf7d48ec5.png">

# 관련 이슈
<!-- TODO, 테스트 유의, 앞으로 구현해야할 기능 -->
- 사이드바 컴포넌트
   - 전역상태로 유저의 내용을 가지고 Drawer가 열렸을 때 [회원 닉네임][회원 정보페이지로 갈 아이디] 사용

# 중점적으로 봐줬으면 하는 부분
- 현재 chakra-ui의 prop이 인라인으로 작성되어 있습니다. 향후 필요에 따라 분리할 예정입니다.