### PR TITLE
[BM-110] 프로필 수정 페이지 레이아웃 구현

### DIFF
--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -1,0 +1,28 @@
+import { EditIcon } from '@chakra-ui/icons';
+import { Flex, InputGroup, Input, InputRightElement } from '@chakra-ui/react';
+
+const NicknameInput = () => (
+  <Flex
+    flexGrow="1"
+    width="100%"
+    paddingRight="19px"
+    paddingLeft="19px"
+    height="70%"
+  >
+    <InputGroup size="md">
+      <Input
+        variant="flushed"
+        size="lg"
+        placeholder="물안경"
+        border="0.7px solid #BFBFBF"
+        borderRadius="10px"
+        paddingLeft="23px"
+      />
+      <InputRightElement paddingRight="16px">
+        <EditIcon width="22px" height="22px" alignSelf="center" />
+      </InputRightElement>
+    </InputGroup>
+  </Flex>
+);
+
+export default NicknameInput;

--- a/components/ProfileEdit/ProfileEditHeader.tsx
+++ b/components/ProfileEdit/ProfileEditHeader.tsx
@@ -1,0 +1,23 @@
+import Header from '@common/header';
+import GoBackIcon from '@common/Header/GoBackIcon';
+import { Text } from '@chakra-ui/react';
+
+const ProfileEditHeader = () => (
+  <Header
+    leftContent={<GoBackIcon />}
+    middleContent={
+      <Text
+        fontFamily="Roboto"
+        fontSize="20px"
+        fontWeight="bold"
+        lineHeight="23px"
+        fontStyle="normal"
+        color="#2E2E2E"
+      >
+        프로필수정
+      </Text>
+    }
+  ></Header>
+);
+
+export default ProfileEditHeader;

--- a/components/ProfileEdit/ProfileImage.tsx
+++ b/components/ProfileEdit/ProfileImage.tsx
@@ -1,0 +1,39 @@
+import { Circle, Avatar, Box, Text } from '@chakra-ui/react';
+
+const ProfileImage = () => (
+  <Circle
+    position="relative"
+    flexDirection="column"
+    border="2px solid #FF4370"
+    overflow="hidden"
+    cursor="pointer"
+  >
+    <Avatar
+      name="Christian Nwamba"
+      size="2xl"
+      src="https://bit.ly/code-beast"
+    />
+    <Box
+      position="absolute"
+      bottom="0"
+      width="100%"
+      height="32px"
+      background="rgba(255, 67, 112, 0.6)"
+      opacity="0.6"
+    >
+      <Text
+        fontFamily="Roboto"
+        fontStyle="normal"
+        fontSize="15px"
+        fontWeight="400"
+        lineHeight="30px"
+        color="white"
+        textAlign="center"
+      >
+        변경
+      </Text>
+    </Box>
+  </Circle>
+);
+
+export default ProfileImage;

--- a/components/ProfileEdit/SubmitButton.tsx
+++ b/components/ProfileEdit/SubmitButton.tsx
@@ -1,0 +1,26 @@
+import { Button, Text } from '@chakra-ui/react';
+
+const SubmitButton = () => (
+  <Button
+    flexShrink="0"
+    justifySelf="flex-end"
+    type="submit"
+    width="100%"
+    height="57px"
+    backgroundColor="#FF4370"
+    cursor="pointer"
+  >
+    <Text
+      fontFamily="Roboto"
+      fontStyle="normal"
+      fontSize="17px"
+      fontWeight="400px"
+      lineHeight="20px"
+      color="white"
+    >
+      완료
+    </Text>
+  </Button>
+);
+
+export default SubmitButton;

--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -1,17 +1,7 @@
-import {
-  Avatar,
-  Box,
-  Center,
-  Circle,
-  Flex,
-  Input,
-  InputGroup,
-  InputRightElement,
-  Text,
-} from '@chakra-ui/react';
-import { EditIcon } from '@chakra-ui/icons';
+import { Center, Flex, Text } from '@chakra-ui/react';
 import ProfileEditHeader from './ProfileEditHeader';
 import ProfileImage from './ProfileImage';
+import NicknameInput from './NicknameInput';
 
 const ProfileEdit = () => {
   return (
@@ -20,27 +10,7 @@ const ProfileEdit = () => {
       <Flex width="100%" height="100%" marginTop="48px">
         <Flex width="100%" direction="column" alignItems="center" gap="48px">
           <ProfileImage />
-          <Flex
-            flexGrow="1"
-            width="100%"
-            paddingRight="19px"
-            paddingLeft="19px"
-            height="70%"
-          >
-            <InputGroup size="md">
-              <Input
-                variant="flushed"
-                size="lg"
-                placeholder="물안경"
-                border="0.7px solid #BFBFBF"
-                borderRadius="10px"
-                paddingLeft="23px"
-              />
-              <InputRightElement paddingRight="16px">
-                <EditIcon width="22px" height="22px" alignSelf="center" />
-              </InputRightElement>
-            </InputGroup>
-          </Flex>
+          <NicknameInput />
           <Center
             flexShrink="0"
             justifySelf="flex-end"

--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -12,25 +12,12 @@ import {
 import { EditIcon } from '@chakra-ui/icons';
 import Header from '@common/header';
 import GoBackIcon from '@common/Header/GoBackIcon';
+import ProfileEditHeader from './ProfileEditHeader';
 
 const ProfileEdit = () => {
   return (
     <Flex flexDirection="column" width="100%" height="100%">
-      <Header
-        leftContent={<GoBackIcon />}
-        middleContent={
-          <Text
-            fontFamily="Roboto"
-            fontSize="20px"
-            fontWeight="bold"
-            lineHeight="23px"
-            fontStyle="normal"
-            color="#2E2E2E"
-          >
-            프로필수정
-          </Text>
-        }
-      ></Header>
+      <ProfileEditHeader />
       <Flex width="100%" height="100%" marginTop="48px">
         <Flex width="100%" direction="column" alignItems="center" gap="48px">
           <Circle

--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -1,0 +1,115 @@
+import {
+  Avatar,
+  Box,
+  Center,
+  Circle,
+  Flex,
+  Input,
+  InputGroup,
+  InputRightElement,
+  Text,
+} from '@chakra-ui/react';
+import { EditIcon } from '@chakra-ui/icons';
+import Header from '@common/header';
+import GoBackIcon from '@common/Header/GoBackIcon';
+
+const ProfileEdit = () => {
+  return (
+    <Flex flexDirection="column" width="100%" height="100%">
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={
+          <Text
+            fontFamily="Roboto"
+            fontSize="20px"
+            fontWeight="bold"
+            lineHeight="23px"
+            fontStyle="normal"
+            color="#2E2E2E"
+          >
+            프로필수정
+          </Text>
+        }
+      ></Header>
+      <Flex width="100%" height="100%" marginTop="48px">
+        <Flex width="100%" direction="column" alignItems="center" gap="48px">
+          <Circle
+            position="relative"
+            flexDirection="column"
+            border="2px solid #FF4370"
+            overflow="hidden"
+            cursor="pointer"
+          >
+            <Avatar
+              name="Christian Nwamba"
+              size="2xl"
+              src="https://bit.ly/code-beast"
+            />
+            <Box
+              position="absolute"
+              bottom="0"
+              width="100%"
+              height="32px"
+              background="rgba(255, 67, 112, 0.6)"
+              opacity="0.6"
+            >
+              <Text
+                fontFamily="Roboto"
+                fontStyle="normal"
+                fontSize="15px"
+                fontWeight="400"
+                lineHeight="30px"
+                color="white"
+                textAlign="center"
+              >
+                변경
+              </Text>
+            </Box>
+          </Circle>
+          <Flex
+            flexGrow="1"
+            width="100%"
+            paddingRight="19px"
+            paddingLeft="19px"
+            height="70%"
+          >
+            <InputGroup size="md">
+              <Input
+                variant="flushed"
+                size="lg"
+                placeholder="물안경"
+                border="0.7px solid #BFBFBF"
+                borderRadius="10px"
+                paddingLeft="23px"
+              />
+              <InputRightElement paddingRight="16px">
+                <EditIcon width="22px" height="22px" alignSelf="center" />
+              </InputRightElement>
+            </InputGroup>
+          </Flex>
+          <Center
+            flexShrink="0"
+            justifySelf="flex-end"
+            width="100%"
+            height="57px"
+            backgroundColor="#FF4370"
+            cursor="pointer"
+          >
+            <Text
+              fontFamily="Roboto"
+              fontStyle="normal"
+              fontSize="17px"
+              fontWeight="400px"
+              lineHeight="20px"
+              color="white"
+            >
+              완료
+            </Text>
+          </Center>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default ProfileEdit;

--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -1,7 +1,8 @@
-import { Center, Flex, Text } from '@chakra-ui/react';
+import { Flex } from '@chakra-ui/react';
 import ProfileEditHeader from './ProfileEditHeader';
 import ProfileImage from './ProfileImage';
 import NicknameInput from './NicknameInput';
+import SubmitButton from './SubmitButton';
 
 const ProfileEdit = () => {
   return (
@@ -11,25 +12,7 @@ const ProfileEdit = () => {
         <Flex width="100%" direction="column" alignItems="center" gap="48px">
           <ProfileImage />
           <NicknameInput />
-          <Center
-            flexShrink="0"
-            justifySelf="flex-end"
-            width="100%"
-            height="57px"
-            backgroundColor="#FF4370"
-            cursor="pointer"
-          >
-            <Text
-              fontFamily="Roboto"
-              fontStyle="normal"
-              fontSize="17px"
-              fontWeight="400px"
-              lineHeight="20px"
-              color="white"
-            >
-              완료
-            </Text>
-          </Center>
+          <SubmitButton />
         </Flex>
       </Flex>
     </Flex>

--- a/components/ProfileEdit/index.tsx
+++ b/components/ProfileEdit/index.tsx
@@ -10,9 +10,8 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { EditIcon } from '@chakra-ui/icons';
-import Header from '@common/header';
-import GoBackIcon from '@common/Header/GoBackIcon';
 import ProfileEditHeader from './ProfileEditHeader';
+import ProfileImage from './ProfileImage';
 
 const ProfileEdit = () => {
   return (
@@ -20,39 +19,7 @@ const ProfileEdit = () => {
       <ProfileEditHeader />
       <Flex width="100%" height="100%" marginTop="48px">
         <Flex width="100%" direction="column" alignItems="center" gap="48px">
-          <Circle
-            position="relative"
-            flexDirection="column"
-            border="2px solid #FF4370"
-            overflow="hidden"
-            cursor="pointer"
-          >
-            <Avatar
-              name="Christian Nwamba"
-              size="2xl"
-              src="https://bit.ly/code-beast"
-            />
-            <Box
-              position="absolute"
-              bottom="0"
-              width="100%"
-              height="32px"
-              background="rgba(255, 67, 112, 0.6)"
-              opacity="0.6"
-            >
-              <Text
-                fontFamily="Roboto"
-                fontStyle="normal"
-                fontSize="15px"
-                fontWeight="400"
-                lineHeight="30px"
-                color="white"
-                textAlign="center"
-              >
-                변경
-              </Text>
-            </Box>
-          </Circle>
+          <ProfileImage />
           <Flex
             flexGrow="1"
             width="100%"

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -1,7 +1,8 @@
+import ProfileEdit from 'components/ProfileEdit';
 import type { NextPage } from 'next';
 
 const Edit: NextPage = () => {
-  return <div>Edit</div>;
+  return <ProfileEdit />;
 };
 
 export default Edit;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
프로필 수정 페이지 레이아웃 구현

# 작업 진행 사항
<img width="388" alt="스크린샷 2022-07-26 오후 10 34 33" src="https://user-images.githubusercontent.com/16220817/181019385-52b5dfb3-fadd-4d6f-885c-5a70cb920616.png">


# 관련 이슈
- 사진 속에 있는 `변경` 글자색을 흰색으로 보여주려고 했는데 잘 안됐습니다.
- 기존에 올렸던 PR의 커밋이 rebase하다 잘못되어서 PR을 다시 올립니다.

# 중점적으로 봐줬으면 하는 부분
<!-- 중점적으로 봐줬으면 하는 부분 -->
`px` 크기들은 최대한 figma 기준으로 구현했습니다.