### PR TITLE
[BM-57] 수정 페이지 기능 구현

### DIFF
--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -21,15 +21,11 @@ const EditProfileForm = () => {
 
       await fakeSubmit();
     },
-    validate: ({ nickname, profile }) => {
+    validate: ({ nickname }) => {
       const error: { nickname?: string; profile?: string } = {};
 
       if (!nickname) {
         error.nickname = '닉네임을 입력해주세요.';
-      }
-
-      if (!profile) {
-        error.profile = '프로필 사진을 등록해주세요.';
       }
 
       return error;

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,4 +1,5 @@
 import { Flex, Text } from '@chakra-ui/react';
+
 import { NicknameInput, SubmitButton } from '.';
 import useForm from '../../hooks/useForm';
 import ProfileImageUpload from './ProfileImageUpload';

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,0 +1,50 @@
+import { Flex, Text } from '@chakra-ui/react';
+import { ProfileImage, NicknameInput, SubmitButton } from '.';
+import useForm from '../../hooks/useForm';
+
+const EditProfileForm = () => {
+  const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
+    initialValues: { nickname: '' },
+    // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
+    onSubmit: async ({ nickname }) => {
+      const fakeSubmit = () =>
+        new Promise(() => {
+          setTimeout(() => {
+            alert(`onSubmit! nickname: ${nickname}`);
+          }, 1500);
+        });
+
+      await fakeSubmit();
+    },
+    validate: ({ nickname }) => {
+      const error: { nickname?: string } = {};
+
+      if (!nickname) {
+        error.nickname = '닉네임을 입력해주세요.';
+      }
+
+      return error;
+    },
+  });
+
+  console.log(isLoading);
+
+  // TODO: error(빈값, 길이제한?, 닉네임 정의 필요) 적절하게 렌더링 해주기. (글자 vs 모달)
+  return (
+    <form style={{ width: '100%', height: '100%' }} onSubmit={handleSubmit}>
+      <Flex width="100%" direction="column" alignItems="center" gap="48px">
+        <ProfileImage />
+        {Object.keys(errors).length > 0 &&
+          Object.values(errors).map((errorMessage, index) => (
+            <Text key={index} size="20px" color="red">
+              {errorMessage as string}
+            </Text>
+          ))}
+        <NicknameInput name="nickname" onChange={handleChange} />
+        <SubmitButton />
+      </Flex>
+    </form>
+  );
+};
+
+export default EditProfileForm;

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,27 +1,32 @@
 import { Flex, Text } from '@chakra-ui/react';
-import { ProfileImage, NicknameInput, SubmitButton } from '.';
+import { NicknameInput, SubmitButton } from '.';
 import useForm from '../../hooks/useForm';
+import ProfileImageUpload from './ProfileImageupload';
 
 const EditProfileForm = () => {
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
-    initialValues: { nickname: '' },
+    initialValues: { nickname: '', profile: '' },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
-    onSubmit: async ({ nickname }) => {
+    onSubmit: async ({ nickname, profile }) => {
       const fakeSubmit = () =>
         new Promise((resolve) => {
           setTimeout(() => {
-            alert(`onSubmit! nickname: ${nickname}`);
+            alert(`onSubmit!\n nickname: ${nickname} \n profile: ${profile}`);
             resolve('Success');
           }, 1500);
         });
 
       await fakeSubmit();
     },
-    validate: ({ nickname }) => {
-      const error: { nickname?: string } = {};
+    validate: ({ nickname, profile }) => {
+      const error: { nickname?: string; profile?: string } = {};
 
       if (!nickname) {
         error.nickname = '닉네임을 입력해주세요.';
+      }
+
+      if (!profile) {
+        error.profile = '프로필 사진을 등록해주세요.';
       }
 
       return error;
@@ -32,7 +37,11 @@ const EditProfileForm = () => {
   return (
     <form style={{ width: '100%', height: '100%' }} onSubmit={handleSubmit}>
       <Flex width="100%" direction="column" alignItems="center" gap="48px">
-        <ProfileImage />
+        <ProfileImageUpload
+          name="profile"
+          profileImageUrl="https://bit.ly/code-beast"
+          onChange={handleChange}
+        />
         {Object.keys(errors).length > 0 &&
           Object.values(errors).map((errorMessage, index) => (
             <Text key={index} size="20px" color="red">

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -16,17 +16,16 @@ const EditProfileForm = ({
   profileImageUrl,
 }: EditProfileFormProps) => {
   const [prevNickname, setPrevNickname] = useState(nickname);
-  const [prevProfileImageUrl, setPrevProfileImageUrl] =
-    useState(profileImageUrl);
+  const [prevProfileImage, setPrevProfileImage] = useState(profileImageUrl);
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
-    initialValues: { nickname, profile: profileImageUrl },
+    initialValues: { nickname, profileImage: profileImageUrl },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
     onSubmit: async ({ nickname, e }) => {
       const fakeSubmit = () =>
         new Promise((resolve) => {
           setTimeout(() => {
             alert(
-              `onSubmit!\n nickname: ${nickname} \n profile: ${e.target.profile.dataset.url}`
+              `onSubmit!\n nickname: ${nickname} \n profileImage: ${e.target.profileImage.dataset.url}`
             );
             resolve('Success');
           }, 1500);
@@ -34,16 +33,16 @@ const EditProfileForm = ({
 
       await fakeSubmit();
       setPrevNickname(nickname);
-      setPrevProfileImageUrl(e.target.profile.value);
+      setPrevProfileImage(e.target.profileImage.value);
     },
-    validate: ({ nickname, profile }) => {
+    validate: ({ nickname, profileImage }) => {
       const error: { nickname?: string } = {};
 
       if (!nickname) {
         error.nickname = '수정할 닉네임을 입력해주세요.';
       }
 
-      if (prevNickname === nickname && prevProfileImageUrl === profile) {
+      if (prevNickname === nickname && prevProfileImage === profileImage) {
         error.nickname = '닉네임이 변경 안됐습니다.';
       }
 
@@ -62,7 +61,7 @@ const EditProfileForm = ({
         gap="48px"
       >
         <ProfileImageUpload
-          name="profile"
+          name="profileImage"
           profileImageUrl={profileImageUrl}
           onChange={handleChange}
         />

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -44,13 +44,23 @@ const EditProfileForm = ({
   // TODO: error(빈값, 길이제한?, 닉네임 정의 필요) 적절하게 렌더링 해주기. (글자 vs 모달)
   return (
     <form style={{ width: '100%', height: '100%' }} onSubmit={handleSubmit}>
-      <Flex width="100%" direction="column" alignItems="center" gap="48px">
+      <Flex
+        width="100%"
+        height="100%"
+        direction="column"
+        alignItems="center"
+        gap="48px"
+      >
         <ProfileImageUpload
           name="profile"
           profileImageUrl={profileImageUrl}
           onChange={handleChange}
         />
         <FormControl
+          flexGrow="1"
+          display="flex"
+          flexDirection="column"
+          height="20%"
           isInvalid={(errors.nickname as string)?.length > 0 ? true : false}
         >
           <NicknameInput

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,7 +1,8 @@
 import { Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
 
+import useForm from 'hooks/useForm';
+
 import { NicknameInput, SubmitButton } from '.';
-import useForm from '../../hooks/useForm';
 import ProfileImageUpload from './ProfileImageUpload';
 
 interface EditProfileFormProps {

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -7,11 +7,13 @@ const EditProfileForm = () => {
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: { nickname: '', profile: '' },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
-    onSubmit: async ({ nickname, profile }) => {
+    onSubmit: async ({ nickname, e }) => {
       const fakeSubmit = () =>
         new Promise((resolve) => {
           setTimeout(() => {
-            alert(`onSubmit!\n nickname: ${nickname} \n profile: ${profile}`);
+            alert(
+              `onSubmit!\n nickname: ${nickname} \n profile: ${e.target.profile.dataset.url}`
+            );
             resolve('Success');
           }, 1500);
         });

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -15,7 +15,7 @@ const EditProfileForm = ({
   profileImageUrl,
 }: EditProfileFormProps) => {
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
-    initialValues: { nickname: '', profile: '' },
+    initialValues: { nickname, profile: profileImageUrl },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
     onSubmit: async ({ nickname, e }) => {
       const fakeSubmit = () =>

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -4,7 +4,15 @@ import { NicknameInput, SubmitButton } from '.';
 import useForm from '../../hooks/useForm';
 import ProfileImageUpload from './ProfileImageUpload';
 
-const EditProfileForm = () => {
+interface EditProfileFormProps {
+  nickname: string;
+  profileImageUrl: string;
+}
+
+const EditProfileForm = ({
+  nickname,
+  profileImageUrl,
+}: EditProfileFormProps) => {
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: { nickname: '', profile: '' },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
@@ -38,13 +46,17 @@ const EditProfileForm = () => {
       <Flex width="100%" direction="column" alignItems="center" gap="48px">
         <ProfileImageUpload
           name="profile"
-          profileImageUrl="https://bit.ly/code-beast"
+          profileImageUrl={profileImageUrl}
           onChange={handleChange}
         />
         <FormControl
           isInvalid={(errors.nickname as string)?.length > 0 ? true : false}
         >
-          <NicknameInput name="nickname" onChange={handleChange} />
+          <NicknameInput
+            inputName="nickname"
+            nickname={nickname}
+            onChange={handleChange}
+          />
           <FormErrorMessage paddingLeft="19px">
             {errors.nickname as string}
           </FormErrorMessage>

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
 
 import { NicknameInput, SubmitButton } from '.';
 import useForm from '../../hooks/useForm';
@@ -22,10 +22,10 @@ const EditProfileForm = () => {
       await fakeSubmit();
     },
     validate: ({ nickname }) => {
-      const error: { nickname?: string; profile?: string } = {};
+      const error: { nickname?: string } = {};
 
       if (!nickname) {
-        error.nickname = '닉네임을 입력해주세요.';
+        error.nickname = '수정할 닉네임을 입력해주세요.';
       }
 
       return error;
@@ -41,13 +41,15 @@ const EditProfileForm = () => {
           profileImageUrl="https://bit.ly/code-beast"
           onChange={handleChange}
         />
-        {Object.keys(errors).length > 0 &&
-          Object.values(errors).map((errorMessage, index) => (
-            <Text key={index} size="20px" color="red">
-              {errorMessage as string}
-            </Text>
-          ))}
-        <NicknameInput name="nickname" onChange={handleChange} />
+        <FormControl
+          isInvalid={(errors.nickname as string)?.length > 0 ? true : false}
+        >
+          <NicknameInput name="nickname" onChange={handleChange} />
+          <FormErrorMessage paddingLeft="19px">
+            {errors.nickname as string}
+          </FormErrorMessage>
+        </FormControl>
+
         <SubmitButton isLoading={isLoading} loadingText={'전송 중'} />
       </Flex>
     </form>

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,4 +1,5 @@
 import { Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
+import { useState } from 'react';
 
 import useForm from 'hooks/useForm';
 
@@ -14,6 +15,9 @@ const EditProfileForm = ({
   nickname,
   profileImageUrl,
 }: EditProfileFormProps) => {
+  const [prevNickname, setPrevNickname] = useState(nickname);
+  const [prevProfileImageUrl, setPrevProfileImageUrl] =
+    useState(profileImageUrl);
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: { nickname, profile: profileImageUrl },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
@@ -29,12 +33,18 @@ const EditProfileForm = ({
         });
 
       await fakeSubmit();
+      setPrevNickname(nickname);
+      setPrevProfileImageUrl(e.target.profile.value);
     },
-    validate: ({ nickname }) => {
+    validate: ({ nickname, profile }) => {
       const error: { nickname?: string } = {};
 
       if (!nickname) {
         error.nickname = '수정할 닉네임을 입력해주세요.';
+      }
+
+      if (prevNickname === nickname && prevProfileImageUrl === profile) {
+        error.nickname = '닉네임이 변경 안됐습니다.';
       }
 
       return error;

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,7 +1,7 @@
 import { Flex, Text } from '@chakra-ui/react';
 import { NicknameInput, SubmitButton } from '.';
 import useForm from '../../hooks/useForm';
-import ProfileImageUpload from './ProfileImageupload';
+import ProfileImageUpload from './ProfileImageUpload';
 
 const EditProfileForm = () => {
   const { errors, isLoading, handleChange, handleSubmit } = useForm({

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -3,14 +3,15 @@ import { ProfileImage, NicknameInput, SubmitButton } from '.';
 import useForm from '../../hooks/useForm';
 
 const EditProfileForm = () => {
-  const { values, errors, isLoading, handleChange, handleSubmit } = useForm({
+  const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: { nickname: '' },
     // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
     onSubmit: async ({ nickname }) => {
       const fakeSubmit = () =>
-        new Promise(() => {
+        new Promise((resolve) => {
           setTimeout(() => {
             alert(`onSubmit! nickname: ${nickname}`);
+            resolve('Success');
           }, 1500);
         });
 
@@ -27,8 +28,6 @@ const EditProfileForm = () => {
     },
   });
 
-  console.log(isLoading);
-
   // TODO: error(빈값, 길이제한?, 닉네임 정의 필요) 적절하게 렌더링 해주기. (글자 vs 모달)
   return (
     <form style={{ width: '100%', height: '100%' }} onSubmit={handleSubmit}>
@@ -41,7 +40,7 @@ const EditProfileForm = () => {
             </Text>
           ))}
         <NicknameInput name="nickname" onChange={handleChange} />
-        <SubmitButton />
+        <SubmitButton isLoading={isLoading} loadingText={'전송 중'} />
       </Flex>
     </form>
   );

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -17,13 +17,7 @@ const NicknameInput = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   return (
-    <Flex
-      flexGrow="1"
-      width="100%"
-      paddingRight="19px"
-      paddingLeft="19px"
-      height="70%"
-    >
+    <Flex width="100%" paddingRight="19px" paddingLeft="19px">
       <InputGroup size="md">
         <Input
           ref={inputRef}

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -36,13 +36,9 @@ const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
           onChange={onChange}
         />
         {visible && (
-          <InputRightElement
-            pointerEvents="none"
-            paddingRight="16px"
-            children={
-              <EditIcon width="22px" height="22px" alignSelf="center" />
-            }
-          />
+          <InputRightElement pointerEvents="none" paddingRight="16px">
+            <EditIcon width="22px" height="22px" alignSelf="center" />
+          </InputRightElement>
         )}
       </InputGroup>
     </Flex>

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -3,11 +3,16 @@ import { Flex, InputGroup, Input, InputRightElement } from '@chakra-ui/react';
 import { ChangeEvent, useRef, useState } from 'react';
 
 interface NicknameInputProps {
-  name: string;
+  inputName: string;
+  nickname: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
+const NicknameInput = ({
+  inputName,
+  nickname,
+  onChange,
+}: NicknameInputProps) => {
   const [visible, setVisible] = useState(true);
   const inputRef = useRef<HTMLInputElement>(null);
   const handleFocus = () => setVisible(false);
@@ -28,11 +33,12 @@ const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
           onBlur={handleBlur}
           variant="flushed"
           size="lg"
-          placeholder="물안경"
+          defaultValue={nickname}
+          placeholder="수정할 닉네임을 입력해주세요"
           border="0.7px solid #BFBFBF"
           borderRadius="10px"
           paddingLeft="23px"
-          name={name}
+          name={inputName}
           onChange={onChange}
         />
         {visible && (

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -4,11 +4,10 @@ import { ChangeEvent } from 'react';
 
 interface NicknameInputProps {
   name: string;
-  nickName: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
 }
 
-const NicknameInput = ({ name, nickName, onChange }: NicknameInputProps) => {
+const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
   return (
     <Flex
       flexGrow="1"
@@ -26,7 +25,6 @@ const NicknameInput = ({ name, nickName, onChange }: NicknameInputProps) => {
           borderRadius="10px"
           paddingLeft="23px"
           name={name}
-          value={nickName}
           onChange={onChange}
         />
         <InputRightElement paddingRight="16px">

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -1,28 +1,40 @@
 import { EditIcon } from '@chakra-ui/icons';
 import { Flex, InputGroup, Input, InputRightElement } from '@chakra-ui/react';
+import { ChangeEvent } from 'react';
 
-const NicknameInput = () => (
-  <Flex
-    flexGrow="1"
-    width="100%"
-    paddingRight="19px"
-    paddingLeft="19px"
-    height="70%"
-  >
-    <InputGroup size="md">
-      <Input
-        variant="flushed"
-        size="lg"
-        placeholder="물안경"
-        border="0.7px solid #BFBFBF"
-        borderRadius="10px"
-        paddingLeft="23px"
-      />
-      <InputRightElement paddingRight="16px">
-        <EditIcon width="22px" height="22px" alignSelf="center" />
-      </InputRightElement>
-    </InputGroup>
-  </Flex>
-);
+interface NicknameInputProps {
+  name: string;
+  nickName: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const NicknameInput = ({ name, nickName, onChange }: NicknameInputProps) => {
+  return (
+    <Flex
+      flexGrow="1"
+      width="100%"
+      paddingRight="19px"
+      paddingLeft="19px"
+      height="70%"
+    >
+      <InputGroup size="md">
+        <Input
+          variant="flushed"
+          size="lg"
+          placeholder="물안경"
+          border="0.7px solid #BFBFBF"
+          borderRadius="10px"
+          paddingLeft="23px"
+          name={name}
+          value={nickName}
+          onChange={onChange}
+        />
+        <InputRightElement paddingRight="16px">
+          <EditIcon width="22px" height="22px" alignSelf="center" />
+        </InputRightElement>
+      </InputGroup>
+    </Flex>
+  );
+};
 
 export default NicknameInput;

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -1,6 +1,6 @@
 import { EditIcon } from '@chakra-ui/icons';
 import { Flex, InputGroup, Input, InputRightElement } from '@chakra-ui/react';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useRef, useState } from 'react';
 
 interface NicknameInputProps {
   name: string;
@@ -8,6 +8,11 @@ interface NicknameInputProps {
 }
 
 const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
+  const [visible, setVisible] = useState(true);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleFocus = () => setVisible(false);
+  const handleBlur = () => setVisible(true);
+
   return (
     <Flex
       flexGrow="1"
@@ -18,6 +23,9 @@ const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
     >
       <InputGroup size="md">
         <Input
+          ref={inputRef}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           variant="flushed"
           size="lg"
           placeholder="물안경"
@@ -27,9 +35,15 @@ const NicknameInput = ({ name, onChange }: NicknameInputProps) => {
           name={name}
           onChange={onChange}
         />
-        <InputRightElement paddingRight="16px">
-          <EditIcon width="22px" height="22px" alignSelf="center" />
-        </InputRightElement>
+        {visible && (
+          <InputRightElement
+            pointerEvents="none"
+            paddingRight="16px"
+            children={
+              <EditIcon width="22px" height="22px" alignSelf="center" />
+            }
+          />
+        )}
       </InputGroup>
     </Flex>
   );

--- a/components/ProfileEdit/NicknameInput.tsx
+++ b/components/ProfileEdit/NicknameInput.tsx
@@ -15,8 +15,6 @@ const NicknameInput = ({
 }: NicknameInputProps) => {
   const [visible, setVisible] = useState(true);
   const inputRef = useRef<HTMLInputElement>(null);
-  const handleFocus = () => setVisible(false);
-  const handleBlur = () => setVisible(true);
 
   return (
     <Flex
@@ -29,8 +27,8 @@ const NicknameInput = ({
       <InputGroup size="md">
         <Input
           ref={inputRef}
-          onFocus={handleFocus}
-          onBlur={handleBlur}
+          onFocus={() => setVisible(false)}
+          onBlur={() => setVisible(true)}
           variant="flushed"
           size="lg"
           defaultValue={nickname}

--- a/components/ProfileEdit/ProfileEditHeader.tsx
+++ b/components/ProfileEdit/ProfileEditHeader.tsx
@@ -1,7 +1,7 @@
 import { Text } from '@chakra-ui/react';
 
-import Header from '@common/Header';
-import GoBackIcon from '@common/Header/GoBackIcon';
+import Header from 'components/common/Header';
+import GoBackIcon from 'components/common/Header/GoBackIcon';
 
 const ProfileEditHeader = () => (
   <Header

--- a/components/ProfileEdit/ProfileImage.tsx
+++ b/components/ProfileEdit/ProfileImage.tsx
@@ -22,7 +22,6 @@ const ProfileImage = ({ propfileImageUrl, onClick }: ProfileImageProps) => (
       width="100%"
       height="32px"
       background="rgba(255, 67, 112, 0.6)"
-      opacity="0.6"
     >
       <Text
         fontFamily="Roboto"

--- a/components/ProfileEdit/ProfileImage.tsx
+++ b/components/ProfileEdit/ProfileImage.tsx
@@ -1,18 +1,20 @@
-import { Circle, Avatar, Box, Text } from '@chakra-ui/react';
+import { Avatar, Box, Circle, Text } from '@chakra-ui/react';
 
-const ProfileImage = () => (
+interface ProfileImageProps {
+  propfileImageUrl: string;
+  onClick: () => void;
+}
+
+const ProfileImage = ({ propfileImageUrl, onClick }: ProfileImageProps) => (
   <Circle
     position="relative"
     flexDirection="column"
     border="2px solid brand.primary-900"
     overflow="hidden"
     cursor="pointer"
+    onClick={onClick}
   >
-    <Avatar
-      name="Christian Nwamba"
-      size="2xl"
-      src="https://bit.ly/code-beast"
-    />
+    <Avatar name="profile-image" size="2xl" src={propfileImageUrl} />
     <Box
       position="absolute"
       bottom="0"

--- a/components/ProfileEdit/ProfileImage.tsx
+++ b/components/ProfileEdit/ProfileImage.tsx
@@ -9,7 +9,8 @@ const ProfileImage = ({ propfileImageUrl, onClick }: ProfileImageProps) => (
   <Circle
     position="relative"
     flexDirection="column"
-    border="2px solid brand.primary-900"
+    border="2px solid"
+    borderColor="brand.primary-900"
     overflow="hidden"
     cursor="pointer"
     onClick={onClick}

--- a/components/ProfileEdit/ProfileImageUpload.tsx
+++ b/components/ProfileEdit/ProfileImageUpload.tsx
@@ -1,5 +1,6 @@
 import { Input } from '@chakra-ui/react';
 import { ChangeEvent, useRef, useState } from 'react';
+
 import { ProfileImage } from '.';
 
 interface ImageUploadProps {

--- a/components/ProfileEdit/ProfileImageUpload.tsx
+++ b/components/ProfileEdit/ProfileImageUpload.tsx
@@ -1,0 +1,55 @@
+import { Input } from '@chakra-ui/react';
+import { ChangeEvent, useRef, useState } from 'react';
+import { ProfileImage } from '.';
+
+interface ImageUploadProps {
+  name: string;
+  profileImageUrl: string;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+}
+
+const ProfileImageUpload = ({
+  name,
+  profileImageUrl,
+  onChange,
+}: ImageUploadProps) => {
+  const [previewImageUrl, setPreviewImageUrl] =
+    useState<string>(profileImageUrl);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const handleChooseFile = () => {
+    inputRef.current && inputRef.current.click();
+  };
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+
+    if (!files) {
+      return;
+    }
+
+    const url = URL.createObjectURL(files[0]);
+    // TODO: S3에서 받아오는 값 넣어주기
+    e.target.value = url;
+
+    setPreviewImageUrl(url);
+    onChange(e);
+  };
+
+  return (
+    <>
+      <Input
+        ref={inputRef}
+        display="none"
+        type="file"
+        name={name}
+        accept="image/*"
+        onChange={handleChange}
+      />
+      <ProfileImage
+        propfileImageUrl={previewImageUrl}
+        onClick={handleChooseFile}
+      />
+    </>
+  );
+};
+
+export default ProfileImageUpload;

--- a/components/ProfileEdit/ProfileImageUpload.tsx
+++ b/components/ProfileEdit/ProfileImageUpload.tsx
@@ -28,7 +28,7 @@ const ProfileImageUpload = ({
 
     const url = URL.createObjectURL(files[0]);
     // TODO: S3에서 받아오는 값 넣어주기
-    e.target.value = url;
+    e.target.dataset.url = url;
 
     setPreviewImageUrl(url);
     onChange(e);

--- a/components/ProfileEdit/ProfileImageUpload.tsx
+++ b/components/ProfileEdit/ProfileImageUpload.tsx
@@ -43,6 +43,7 @@ const ProfileImageUpload = ({
         type="file"
         name={name}
         accept="image/*"
+        data-url={previewImageUrl}
         onChange={handleChange}
       />
       <ProfileImage

--- a/components/ProfileEdit/SubmitButton.tsx
+++ b/components/ProfileEdit/SubmitButton.tsx
@@ -1,7 +1,14 @@
 import { Button, Text } from '@chakra-ui/react';
 
-const SubmitButton = () => (
+interface SubmitButtonProps {
+  isLoading: boolean;
+  loadingText: string;
+}
+
+const SubmitButton = ({ isLoading, loadingText }: SubmitButtonProps) => (
   <Button
+    isLoading={isLoading}
+    loadingText={loadingText}
     flexShrink="0"
     justifySelf="flex-end"
     type="submit"

--- a/components/ProfileEdit/SubmitButton.tsx
+++ b/components/ProfileEdit/SubmitButton.tsx
@@ -9,8 +9,9 @@ const SubmitButton = ({ isLoading, loadingText }: SubmitButtonProps) => (
   <Button
     isLoading={isLoading}
     loadingText={loadingText}
-    flexShrink="0"
-    justifySelf="flex-end"
+    position="fixed"
+    bottom="0"
+    maxWidth="768px"
     type="submit"
     width="100%"
     height="57px"

--- a/components/ProfileEdit/SubmitButton.tsx
+++ b/components/ProfileEdit/SubmitButton.tsx
@@ -16,6 +16,7 @@ const SubmitButton = ({ isLoading, loadingText }: SubmitButtonProps) => (
     height="57px"
     backgroundColor="brand.primary-900"
     cursor="pointer"
+    _hover={{ bg: 'brand.primary-900' }}
   >
     <Text
       fontFamily="Roboto"

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -3,7 +3,7 @@ import { ChangeEvent, useState } from 'react';
 interface useFormProps<InitialValuesType> {
   initialValues: InitialValuesType;
   onSubmit: (values: InitialValuesType) => void;
-  validate: (initialValues: InitialValuesType) => InitialValuesType | {};
+  validate: (initialValues: InitialValuesType) => InitialValuesType;
 }
 
 const useForm = ({ initialValues, onSubmit, validate }: useFormProps<any>) => {

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -24,7 +24,7 @@ const useForm = ({ initialValues, onSubmit, validate }: useFormProps<any>) => {
     const newErrors = validate ? validate(values) : {};
 
     if (Object.keys(newErrors).length === 0) {
-      await onSubmit({ ...values });
+      await onSubmit({ ...values, e });
     }
 
     setErrors(newErrors);

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,0 +1,44 @@
+import { ChangeEvent, useState } from 'react';
+
+type InitialValuesType = {};
+
+interface useFormProps {
+  initialValues: InitialValuesType;
+  onSubmit: (values: InitialValuesType) => void;
+  validate: (initialValues: InitialValuesType) => {};
+}
+
+const useForm = ({ initialValues, onSubmit, validate }: useFormProps) => {
+  const [values, setValues] = useState(initialValues);
+  const [errors, setErrors] = useState({});
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+
+    setValues({ ...values, [name]: value });
+  };
+
+  const handleSubmit = async (e: SubmitEvent) => {
+    setIsLoading(true);
+    e.preventDefault();
+
+    const newErrors = validate ? validate(values) : {};
+
+    if (Object.keys(newErrors).length === 0) {
+      await onSubmit({ ...values });
+    }
+
+    setErrors(newErrors);
+    setIsLoading(false);
+  };
+  return {
+    values,
+    errors,
+    isLoading,
+    handleChange,
+    handleSubmit,
+  };
+};
+
+export default useForm;

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -1,14 +1,12 @@
 import { ChangeEvent, useState } from 'react';
 
-type InitialValuesType = {};
-
-interface useFormProps {
+interface useFormProps<InitialValuesType> {
   initialValues: InitialValuesType;
   onSubmit: (values: InitialValuesType) => void;
-  validate: (initialValues: InitialValuesType) => {};
+  validate: (initialValues: InitialValuesType) => InitialValuesType | {};
 }
 
-const useForm = ({ initialValues, onSubmit, validate }: useFormProps) => {
+const useForm = ({ initialValues, onSubmit, validate }: useFormProps<any>) => {
   const [values, setValues] = useState(initialValues);
   const [errors, setErrors] = useState({});
   const [isLoading, setIsLoading] = useState(false);
@@ -19,7 +17,7 @@ const useForm = ({ initialValues, onSubmit, validate }: useFormProps) => {
     setValues({ ...values, [name]: value });
   };
 
-  const handleSubmit = async (e: SubmitEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     setIsLoading(true);
     e.preventDefault();
 

--- a/hooks/useForm.ts
+++ b/hooks/useForm.ts
@@ -8,7 +8,7 @@ interface useFormProps<InitialValuesType> {
 
 const useForm = ({ initialValues, onSubmit, validate }: useFormProps<any>) => {
   const [values, setValues] = useState(initialValues);
-  const [errors, setErrors] = useState({});
+  const [errors, setErrors] = useState<Record<string, unknown>>({});
   const [isLoading, setIsLoading] = useState(false);
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -5,11 +5,16 @@ import { ProfileEditHeader } from 'components/ProfileEdit';
 import EditProfileForm from 'components/ProfileEdit/EditForm';
 
 const Edit: NextPage = () => {
+  const dummyProps = {
+    nickname: '물안경',
+    profileImageUrl: 'https://bit.ly/code-beast',
+  };
+
   return (
     <Flex flexDirection="column" width="100%" height="100%">
       <ProfileEditHeader />
       <Flex width="100%" height="100%" marginTop="48px">
-        <EditProfileForm />
+        <EditProfileForm {...dummyProps} />
       </Flex>
     </Flex>
   );

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -1,38 +1,15 @@
 import { Flex } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
-import {
-  NicknameInput,
-  ProfileEditHeader,
-  ProfileImage,
-  SubmitButton,
-} from 'components/ProfileEdit';
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ProfileEditHeader } from 'components/ProfileEdit';
+import EditProfileForm from 'components/ProfileEdit/EditForm';
 
 const Edit: NextPage = () => {
-  const [nickname, setNickname] = useState('');
-  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    console.log(e.target.name);
-    setNickname(e.target.value);
-  };
-
-  useEffect(() => {
-    console.log(nickname);
-  }, [nickname]);
-
   return (
     <Flex flexDirection="column" width="100%" height="100%">
       <ProfileEditHeader />
       <Flex width="100%" height="100%" marginTop="48px">
-        <Flex width="100%" direction="column" alignItems="center" gap="48px">
-          <ProfileImage />
-          <NicknameInput
-            name="nickname-input"
-            nickName={nickname}
-            onChange={handleInputChange}
-          />
-          <SubmitButton />
-        </Flex>
+        <EditProfileForm />
       </Flex>
     </Flex>
   );

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -1,6 +1,7 @@
 import { Flex } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
+import { SEO } from 'components/common';
 import { ProfileEditHeader } from 'components/ProfileEdit';
 import EditProfileForm from 'components/ProfileEdit/EditForm';
 
@@ -11,12 +12,15 @@ const Edit: NextPage = () => {
   };
 
   return (
-    <Flex flexDirection="column" width="100%" height="100%">
-      <ProfileEditHeader />
-      <Flex width="100%" height="100%" marginTop="48px">
-        <EditProfileForm {...dummyProps} />
+    <>
+      <SEO title="프로필 수정" />
+      <Flex flexDirection="column" width="100%" height="100%">
+        <ProfileEditHeader />
+        <Flex width="100%" height="100%" marginTop="48px">
+          <EditProfileForm {...dummyProps} />
+        </Flex>
       </Flex>
-    </Flex>
+    </>
   );
 };
 

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -7,15 +7,30 @@ import {
   ProfileImage,
   SubmitButton,
 } from 'components/ProfileEdit';
+import { ChangeEvent, useEffect, useState } from 'react';
 
 const Edit: NextPage = () => {
+  const [nickname, setNickname] = useState('');
+  const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
+    console.log(e.target.name);
+    setNickname(e.target.value);
+  };
+
+  useEffect(() => {
+    console.log(nickname);
+  }, [nickname]);
+
   return (
     <Flex flexDirection="column" width="100%" height="100%">
       <ProfileEditHeader />
       <Flex width="100%" height="100%" marginTop="48px">
         <Flex width="100%" direction="column" alignItems="center" gap="48px">
           <ProfileImage />
-          <NicknameInput />
+          <NicknameInput
+            name="nickname-input"
+            nickName={nickname}
+            onChange={handleInputChange}
+          />
           <SubmitButton />
         </Flex>
       </Flex>


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
수정 페이지 기능 구현 (추후 api 연동 필요)


# 작업 진행 사항

https://user-images.githubusercontent.com/16220817/181895394-08043064-68b4-4b8d-af12-bba13fbe2472.mov

- useForm 완성
- 닉네임, 프로필 이미지 변경
- 에러 메세지 인풋 하단에 표시
- submit시 닉네임, 이미지(현재는 url) 정보 전달 확인

# 관련 이슈
- 불가능한 닉네임 정의 필요
  - 빈 문자열
  - 특수문자
  - 기타 등
 
- 제출 버튼 색 변화
  - 엔터로 제출 시 완료 후 정상 복귀
  - 마우스 클릭시 색깔이 변함 (왜??)

# 중점적으로 봐줬으면 하는 부분
- 빈 객체(`{}`) 타입을 어떻게 타입을 정해야 할까요.
  - `useForm` 의 `errors` 
  -`Record<string, unknown>`로 정의 후 사용하는 곳에서 `as string` 식으로 할당해서 사용.
- 제출 버튼 동작
  - ~버튼 색 변화에 대한 로직을 정확히 이해 못하고 있는데 제출 완료 후 원래색으로 변경하고 싶습니다.~
  - 버튼에 `hover` 속성 추가해서 해결. thanks 맥스. 자세한 원인은 확인 필요.
- 제출 버튼 width
  - figma에서 가로 화면을 다 채웠는데 width를 어떻게 설정하면 좋을지 잘 모르겠습니다.  