### PR TITLE
[BM-146] 회원 정보 입찰한 상품 페이지 레이아웃 구현

### DIFF
--- a/components/User/NoBidProducts.tsx
+++ b/components/User/NoBidProducts.tsx
@@ -1,0 +1,28 @@
+import { Button, Image, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+
+const NoBidProducts = () => {
+  const router = useRouter();
+
+  return (
+    <>
+      <Image src="/svg/noneProduct.svg" alt="None Product" />
+      <Text marginTop="34px">아직 입찰하신 상품이 없으시군요:(</Text>
+      <Text marginTop="10px" color="#8E8E8E">
+        메인화면에서 다양한 상품을 구경하세요!
+      </Text>
+      <Button
+        marginTop="24px"
+        padding="10px 30px"
+        borderRadius="30px"
+        color="white"
+        backgroundColor="brand.primary-900"
+        onClick={() => router.push(`/`)}
+      >
+        메인 페이지로 이동하기
+      </Button>
+    </>
+  );
+};
+
+export default NoBidProducts;

--- a/components/User/index.tsx
+++ b/components/User/index.tsx
@@ -1,1 +1,2 @@
+export { default as NoBidProducts } from './NoBidProducts';
 export { default as NoSellProducts } from './NoSellProducts';

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -4,11 +4,13 @@ import type { NextPage } from 'next';
 import { GoBackIcon, Header, SEO } from 'components/common';
 import { NoBidProducts } from 'components/User';
 
+// @ TODO 데이터 가져와서 연결 작업
 const DUMMY = [];
 
 const Bid: NextPage = () => {
   return (
     <>
+      {/* @ TODO 실제 사용자 닉네임으로 교체 예정 */}
       <SEO title="사용자 이름" />
       <Header
         leftContent={<GoBackIcon />}

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -1,7 +1,28 @@
+import { Center, Text } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
+import { GoBackIcon, Header, SEO } from 'components/common';
+import { NoBidProducts } from 'components/User';
+
+const DUMMY = [];
+
 const Bid: NextPage = () => {
-  return <div>Bid</div>;
+  return (
+    <>
+      <SEO title="사용자 이름" />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<Text>입찰한 상품</Text>}
+      />
+      {DUMMY.length === 0 ? (
+        <Center flexDirection="column" height="100%">
+          <NoBidProducts />
+        </Center>
+      ) : (
+        <Text>list of Product Cards</Text>
+      )}
+    </>
+  );
 };
 
 export default Bid;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 회원 정보 페이지 -> 입찰한 상품 페이지 레이아웃 구현
   - `메인 페이지로 이동 하기` 클릭시 메인 페이지로 이동

# 작업 진행 사항
<img width="640" alt="스크린샷 2022-07-30 22 16 10" src="https://user-images.githubusercontent.com/75886763/181916067-78edee7b-7e96-4073-ba75-1e2f678fb007.png">

# 관련 이슈
- 현재 입찰한 상품이 없다는 가정을 두기위해 DUMMY 데이터를 두었습니다.

# 중점적으로 봐줬으면 하는 부분
- 없습니다.