### PR TITLE
[BM-147] 회원 정보 찜한 상품 페이지 레이아웃 구현

### DIFF
--- a/components/User/NoLikeProducts.tsx
+++ b/components/User/NoLikeProducts.tsx
@@ -1,0 +1,28 @@
+import { Button, Image, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+
+const NoLikeProducts = () => {
+  const router = useRouter();
+
+  return (
+    <>
+      <Image src="/svg/noneProduct.svg" alt="None Product" />
+      <Text marginTop="34px">아직 찜하신 상품이 없으시군요:(</Text>
+      <Text marginTop="10px" color="#8E8E8E">
+        마음에 드는 상품을 찜하고 간편하게 확인하세요!
+      </Text>
+      <Button
+        marginTop="24px"
+        padding="10px 30px"
+        borderRadius="30px"
+        color="white"
+        backgroundColor="brand.primary-900"
+        onClick={() => router.push(`/`)}
+      >
+        메인 페이지로 이동하기
+      </Button>
+    </>
+  );
+};
+
+export default NoLikeProducts;

--- a/components/User/index.tsx
+++ b/components/User/index.tsx
@@ -1,1 +1,2 @@
 export { default as NoSellProducts } from './NoSellProducts';
+export { default as NoLikeProducts } from './NoLikeProducts';

--- a/pages/user/[userId]/products/like/index.tsx
+++ b/pages/user/[userId]/products/like/index.tsx
@@ -4,11 +4,13 @@ import type { NextPage } from 'next';
 import { GoBackIcon, Header, SEO } from 'components/common';
 import { NoLikeProducts } from 'components/User';
 
+// @ TODO 데이터 가져와서 연결 작업
 const DUMMY = [];
 
 const Like: NextPage = () => {
   return (
     <>
+      {/* @ TODO 실제 사용자 닉네임으로 교체 예정 */}
       <SEO title="사용자 이름" />
       <Header
         leftContent={<GoBackIcon />}

--- a/pages/user/[userId]/products/like/index.tsx
+++ b/pages/user/[userId]/products/like/index.tsx
@@ -1,7 +1,28 @@
+import { Center, Text } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
+import { GoBackIcon, Header, SEO } from 'components/common';
+import { NoLikeProducts } from 'components/User';
+
+const DUMMY = [];
+
 const Like: NextPage = () => {
-  return <div>Like</div>;
+  return (
+    <>
+      <SEO title="사용자 이름" />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<Text>찜한 상품</Text>}
+      />
+      {DUMMY.length === 0 ? (
+        <Center flexDirection="column" height="100%">
+          <NoLikeProducts />
+        </Center>
+      ) : (
+        <Text>list of Product Cards</Text>
+      )}
+    </>
+  );
 };
 
 export default Like;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 회원 정보 페이지 -> 찜한 상품 페이지 레이아웃 구현
   - `메인 페이지로 이동 하기` 클릭시 메인 페이지로 이동

# 작업 진행 사항
<img width="640" alt="스크린샷 2022-07-30 22 26 21" src="https://user-images.githubusercontent.com/75886763/181916420-51a40a35-78fc-44d4-b217-e7af18569ad5.png">

# 관련 이슈
- 현재 찜한 상품이 없다는 가정을 두기위해 DUMMY 데이터를 두었습니다.

# 중점적으로 봐줬으면 하는 부분
- 없습니다.