### PR TITLE
[BM-123] 상품 상세페이지 상품 조회 기능 구현과 API 연동

### DIFF
--- a/apis/api/product/index.ts
+++ b/apis/api/product/index.ts
@@ -1,9 +1,9 @@
 import { baseInstance } from 'apis/utils/baseInstance';
-import { ProductResponseType } from 'types/product';
+import { ProductResponse } from 'types/product';
 
 const productAPI = {
   getProduct: (productId: number) =>
-    baseInstance.get<ProductResponseType>(`/products/${productId}`),
+    baseInstance.get<ProductResponse>(`/products/${productId}`),
 };
 
 export default productAPI;

--- a/apis/api/product/index.ts
+++ b/apis/api/product/index.ts
@@ -1,7 +1,9 @@
 import { baseInstance } from 'apis/utils/baseInstance';
+import { ProductResponseType } from 'types/product';
 
 const productAPI = {
-  getProduct: (productId: number) => baseInstance.get(`/products/${productId}`),
+  getProduct: (productId: number) =>
+    baseInstance.get<ProductResponseType>(`/products/${productId}`),
 };
 
 export default productAPI;

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -10,9 +10,14 @@ import {
 
 import ProductBidProgress from './ProductBidDrawer';
 
-const ProductBid = () => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
+interface ProductBidProps {
+  minimumPrice: number;
+  expireAt: Date;
+}
 
+const ProductBid = ({ minimumPrice, expireAt }: ProductBidProps) => {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  3;
   return (
     <Box
       position="fixed"
@@ -40,7 +45,7 @@ const ProductBid = () => {
             borderRadius="20px"
             fontWeight="bold"
           >
-            10,000원
+            {minimumPrice}
           </Text>
         </Flex>
         <Flex justifyContent="space-between" alignItems="center">
@@ -54,7 +59,7 @@ const ProductBid = () => {
             padding="3px 10px"
             borderRadius="20px"
           >
-            01일 22시간 22분 40초
+            {expireAt.toString()}
           </Text>
         </Flex>
         <Button

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -7,6 +7,9 @@ import {
   useDisclosure,
   Image,
 } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+
+import { priceFormat, remainedTimeFormat } from 'utils';
 
 import ProductBidProgress from './ProductBidDrawer';
 
@@ -17,7 +20,12 @@ interface ProductBidProps {
 
 const ProductBid = ({ minimumPrice, expireAt }: ProductBidProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  3;
+  const [remainedTime, setRemainedTime] = useState('0초');
+
+  useEffect(() => {
+    setRemainedTime(remainedTimeFormat(expireAt));
+  }, [remainedTime]);
+
   return (
     <Box
       position="fixed"
@@ -45,7 +53,7 @@ const ProductBid = ({ minimumPrice, expireAt }: ProductBidProps) => {
             borderRadius="20px"
             fontWeight="bold"
           >
-            {minimumPrice}
+            {priceFormat(minimumPrice)}
           </Text>
         </Flex>
         <Flex justifyContent="space-between" alignItems="center">
@@ -59,7 +67,7 @@ const ProductBid = ({ minimumPrice, expireAt }: ProductBidProps) => {
             padding="3px 10px"
             borderRadius="20px"
           >
-            {expireAt.toString()}
+            {remainedTime}
           </Text>
         </Flex>
         <Button

--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -13,7 +13,7 @@ const ProductImage = ({ images }: ProductImageProps) => {
       height="317px"
       objectFit="cover"
       alt="product-image"
-      src={images[0].url}
+      src={images.length ? images[0].url : '/svg/basket.svg'}
     />
   );
 };

--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -1,13 +1,19 @@
 import { Image } from '@chakra-ui/react';
 
-const ProductImage = () => {
+import { Image as ImageType } from 'types/product';
+
+interface ProductImageProps {
+  images: ImageType[];
+}
+
+const ProductImage = ({ images }: ProductImageProps) => {
   return (
     <Image
       width="100%"
       height="317px"
-      objectFit="contain"
+      objectFit="cover"
       alt="product-image"
-      src="https://bit.ly/code-beast"
+      src={images[0].url}
     />
   );
 };

--- a/components/ProductDetail/ProductInfo.tsx
+++ b/components/ProductDetail/ProductInfo.tsx
@@ -1,6 +1,20 @@
 import { Flex, Text } from '@chakra-ui/react';
 
-const ProductInfo = () => {
+interface ProductInfoProps {
+  title: string;
+  description: string;
+  category: string;
+  location: string;
+  createdAt: Date;
+}
+
+const ProductInfo = ({
+  title,
+  description,
+  category,
+  location,
+  createdAt,
+}: ProductInfoProps) => {
   return (
     <Flex direction="column">
       <Flex marginTop="14px" alignItems="center">
@@ -15,16 +29,14 @@ const ProductInfo = () => {
           D-1
         </Text>
         <Text fontSize="lg" marginLeft="10px" fontWeight="bold">
-          춘식이가 먹다 남은 귤
+          {title}
         </Text>
       </Flex>
       <Text fontSize="sm" color="#838383" marginTop="7px">
-        10월 27일
+        {createdAt.toString()}
       </Text>
       <Text marginTop="14px" whiteSpace="pre-wrap" marginBottom="158px">
-        라이언이 키우는 춘식이! 고구마를 제일 좋아하지만 겨울에 이불을 덮고 귤을
-        까먹는 맛이 있죠잉~ 귀여운 춘식이가 먹다 남은 귤 모음! 가볍게 만원부터
-        시작하겠습니다.
+        {description}
       </Text>
     </Flex>
   );

--- a/components/ProductDetail/ProductInfo.tsx
+++ b/components/ProductDetail/ProductInfo.tsx
@@ -1,4 +1,5 @@
 import { Flex, Text } from '@chakra-ui/react';
+import { differenceInDays, format } from 'date-fns';
 
 interface ProductInfoProps {
   title: string;
@@ -6,6 +7,7 @@ interface ProductInfoProps {
   category: string;
   location: string;
   createdAt: Date;
+  expireAt: Date;
 }
 
 const ProductInfo = ({
@@ -14,7 +16,10 @@ const ProductInfo = ({
   category,
   location,
   createdAt,
+  expireAt,
 }: ProductInfoProps) => {
+  const DDay = differenceInDays(new Date(expireAt), new Date());
+
   return (
     <Flex direction="column">
       <Flex marginTop="14px" alignItems="center">
@@ -26,14 +31,14 @@ const ProductInfo = ({
           borderRadius="20px"
           fontWeight="bold"
         >
-          D-1
+          D-{DDay === 0 ? 'Day' : DDay}
         </Text>
         <Text fontSize="lg" marginLeft="10px" fontWeight="bold">
           {title}
         </Text>
       </Flex>
       <Text fontSize="sm" color="#838383" marginTop="7px">
-        {createdAt.toString()}
+        {format(new Date(createdAt), 'M월 d일')}
       </Text>
       <Text marginTop="14px" whiteSpace="pre-wrap" marginBottom="158px">
         {description}

--- a/components/ProductDetail/ProductSeller.tsx
+++ b/components/ProductDetail/ProductSeller.tsx
@@ -2,15 +2,15 @@ import { Flex, Image, Text } from '@chakra-ui/react';
 
 interface ProductSeller {
   name: string;
-  profileImageUrl: string;
+  thumbnailImg: string;
 }
 
-const ProductSeller = ({ name, profileImageUrl }: ProductSeller) => {
+const ProductSeller = ({ name, thumbnailImg }: ProductSeller) => {
   return (
     <Flex alignItems="center">
       <Image
         alt="profile-image"
-        src={profileImageUrl}
+        src={thumbnailImg}
         w="45px"
         h="45px"
         borderRadius="50%"

--- a/components/ProductDetail/ProductSeller.tsx
+++ b/components/ProductDetail/ProductSeller.tsx
@@ -1,11 +1,16 @@
 import { Flex, Image, Text } from '@chakra-ui/react';
 
-const SellerInfo = () => {
+interface ProductSeller {
+  name: string;
+  profileImageUrl: string;
+}
+
+const ProductSeller = ({ name, profileImageUrl }: ProductSeller) => {
   return (
     <Flex alignItems="center">
       <Image
         alt="profile-image"
-        src="https://bit.ly/code-beast"
+        src={profileImageUrl}
         w="45px"
         h="45px"
         borderRadius="50%"
@@ -15,10 +20,10 @@ const SellerInfo = () => {
         borderColor="brand.primary-900"
       />
       <Text fontWeight="bold" marginLeft="14px">
-        워터
+        {name}
       </Text>
     </Flex>
   );
 };
 
-export default SellerInfo;
+export default ProductSeller;

--- a/components/common/Card/index.tsx
+++ b/components/common/Card/index.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router';
 import CardImage from './CardImage';
 
 interface CardProps {
-  productId: string;
+  productId: number;
 }
 
 const Card = ({ productId }: CardProps) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
         "axios": "^0.27.2",
+        "date-fns": "^2.29.1",
         "framer-motion": "^6.5.1",
         "next": "12.2.3",
         "react": "18.2.0",
@@ -2582,6 +2583,18 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "node_modules/date-fns": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -7189,6 +7202,11 @@
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true
+    },
+    "date-fns": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.1.tgz",
+      "integrity": "sha512-dlLD5rKaKxpFdnjrs+5azHDFOPEu4ANy/LTh04A1DTzMM7qoajmKCBc8pkKRFT41CNzw+4gQh79X5C+Jq27HAw=="
     },
     "debug": {
       "version": "4.3.4",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
     "axios": "^0.27.2",
+    "date-fns": "^2.29.1",
     "framer-motion": "^6.5.1",
     "next": "12.2.3",
     "react": "18.2.0",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -19,7 +19,7 @@ const Home: NextPage = () => {
           .map((_, index) => {
             return (
               <Fragment key={index}>
-                <Card productId={index.toString()} />
+                <Card productId={index} />
                 <Divider />
               </Fragment>
             );

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -44,8 +44,8 @@ const ProductDetail = ({
         <ProductImage images={images} />
         <Flex justifyContent="space-between" alignItems="center">
           <ProductSeller
-            name={writer.name}
-            profileImageUrl={writer.profileImageUrl}
+            name={writer.username}
+            thumbnailImg={writer.thumbnailImg}
           />
           <StarIcon w="23px" color="brand.primary-900" />
         </Flex>

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -10,7 +10,6 @@ import {
   ProductInfo,
   ProductSeller,
 } from 'components/ProductDetail';
-import { Product } from 'types/product';
 
 export const getServerSideProps = async (context: any) => {
   const { productId } = context.query;
@@ -36,7 +35,7 @@ const ProductDetail = ({
     imageUrls,
     expireAt,
     createdAt,
-  } = product as Product;
+  } = product;
 
   return (
     <>

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -40,11 +40,14 @@ const ProductDetail = ({
   return (
     <>
       <SEO title={title} description={description} />
+      <Box position="absolute">
+        <ProductImage images={images} />
+      </Box>
       <Box position="absolute" left="0" paddingTop="5px" cursor="pointer">
+        {/* //TODO 색상 props 적용 */}
         <GoBackIcon />
       </Box>
-      <Flex direction="column" width="100%">
-        <ProductImage images={images} />
+      <Flex direction="column" width="100%" marginTop="317px">
         <Flex justifyContent="space-between" alignItems="center">
           <ProductSeller
             name={writer.username}

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -1,9 +1,9 @@
 import { StarIcon } from '@chakra-ui/icons';
-import { Divider, Flex } from '@chakra-ui/react';
+import { Divider, Flex, Box } from '@chakra-ui/react';
 import type { InferGetServerSidePropsType } from 'next';
 
 import { productAPI } from 'apis';
-import { SEO } from 'components/common';
+import { GoBackIcon, SEO } from 'components/common';
 import {
   ProductBid,
   ProductImage,
@@ -40,6 +40,9 @@ const ProductDetail = ({
   return (
     <>
       <SEO title={title} description={description} />
+      <Box position="absolute" left="0" paddingTop="5px" cursor="pointer">
+        <GoBackIcon />
+      </Box>
       <Flex direction="column" width="100%">
         <ProductImage images={images} />
         <Flex justifyContent="space-between" alignItems="center">

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -1,7 +1,8 @@
 import { StarIcon } from '@chakra-ui/icons';
 import { Divider, Flex } from '@chakra-ui/react';
-import type { NextPage } from 'next';
+import type { InferGetServerSidePropsType } from 'next';
 
+import { productAPI } from 'apis';
 import { SEO } from 'components/common';
 import {
   ProductBid,
@@ -9,20 +10,55 @@ import {
   ProductInfo,
   ProductSeller,
 } from 'components/ProductDetail';
+import { Product } from 'types/product';
 
-const ProductDetail: NextPage = () => {
+export const getServerSideProps = async (context: any) => {
+  const { productId } = context.query;
+  const { data } = await productAPI.getProduct(productId);
+
+  return {
+    props: {
+      product: data,
+    },
+  };
+};
+
+const ProductDetail = ({
+  product,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const {
+    title,
+    description,
+    minimumPrice,
+    category,
+    location,
+    writer,
+    imageUrls,
+    expireAt,
+    createdAt,
+  } = product as Product;
+
   return (
     <>
-      <SEO title="상세 상품 중고 거래 이름" />
-      <Flex direction="column">
+      <SEO title={title} description={description} />
+      <Flex direction="column" width="100%">
         <ProductImage />
         <Flex justifyContent="space-between" alignItems="center">
-          <ProductSeller />
+          <ProductSeller
+            name={writer.name}
+            profileImageUrl={writer.profileImageUrl}
+          />
           <StarIcon w="22px" color="brand.primary-900" />
         </Flex>
         <Divider />
-        <ProductInfo />
-        <ProductBid />
+        <ProductInfo
+          title={title}
+          description={description}
+          category={category}
+          location={location}
+          createdAt={createdAt}
+        />
+        <ProductBid minimumPrice={minimumPrice} expireAt={expireAt} />
       </Flex>
     </>
   );

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -1,6 +1,6 @@
 import { StarIcon } from '@chakra-ui/icons';
 import { Divider, Flex, Box } from '@chakra-ui/react';
-import type { InferGetServerSidePropsType } from 'next';
+import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 
 import { productAPI } from 'apis';
 import { GoBackIcon, SEO } from 'components/common';
@@ -11,9 +11,9 @@ import {
   ProductSeller,
 } from 'components/ProductDetail';
 
-export const getServerSideProps = async (context: any) => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const { productId } = context.query;
-  const { data } = await productAPI.getProduct(productId);
+  const { data } = await productAPI.getProduct(Number(productId));
 
   return {
     props: {

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -32,7 +32,7 @@ const ProductDetail = ({
     category,
     location,
     writer,
-    imageUrls,
+    images,
     expireAt,
     createdAt,
   } = product;
@@ -41,13 +41,13 @@ const ProductDetail = ({
     <>
       <SEO title={title} description={description} />
       <Flex direction="column" width="100%">
-        <ProductImage />
+        <ProductImage images={images} />
         <Flex justifyContent="space-between" alignItems="center">
           <ProductSeller
             name={writer.name}
             profileImageUrl={writer.profileImageUrl}
           />
-          <StarIcon w="22px" color="brand.primary-900" />
+          <StarIcon w="23px" color="brand.primary-900" />
         </Flex>
         <Divider />
         <ProductInfo
@@ -56,6 +56,7 @@ const ProductDetail = ({
           category={category}
           location={location}
           createdAt={createdAt}
+          expireAt={expireAt}
         />
         <ProductBid minimumPrice={minimumPrice} expireAt={expireAt} />
       </Flex>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -24,7 +24,7 @@ const Products: NextPage = () => {
         .map((_, index) => {
           return (
             <Fragment key={index}>
-              <Card productId={index.toString()} />
+              <Card productId={index} />
               <Divider />
             </Fragment>
           );

--- a/types/product/index.ts
+++ b/types/product/index.ts
@@ -1,0 +1,20 @@
+import { User } from 'types/user';
+
+export interface Image {
+  order: number;
+  url: string;
+}
+
+export interface Product {
+  id: number;
+  title: string;
+  description: string;
+  minimumPrice: number;
+  category: string;
+  location: string;
+  expireAt: Date;
+  createdAt: Date;
+  updatedAt: Date;
+  writer: User;
+  imageUrls: Image[];
+}

--- a/types/product/index.ts
+++ b/types/product/index.ts
@@ -5,7 +5,7 @@ export interface Image {
   url: string;
 }
 
-export interface Product {
+export interface ProductResponseType {
   id: number;
   title: string;
   description: string;

--- a/types/product/index.ts
+++ b/types/product/index.ts
@@ -16,5 +16,5 @@ export interface ProductResponse {
   createdAt: Date;
   updatedAt: Date;
   writer: User;
-  imageUrls: Image[];
+  images: Image[];
 }

--- a/types/product/index.ts
+++ b/types/product/index.ts
@@ -5,7 +5,7 @@ export interface Image {
   url: string;
 }
 
-export interface ProductResponseType {
+export interface ProductResponse {
   id: number;
   title: string;
   description: string;

--- a/types/user/index.ts
+++ b/types/user/index.ts
@@ -1,5 +1,5 @@
 export interface User {
-  id: string;
-  name: string;
-  profileImageUrl: string;
+  encodedId: string;
+  username: string;
+  thumbnailImg: string;
 }

--- a/types/user/index.ts
+++ b/types/user/index.ts
@@ -1,0 +1,5 @@
+export interface User {
+  id: string;
+  name: string;
+  profileImageUrl: string;
+}

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,0 +1,2 @@
+export { default as priceFormat } from './priceFormat';
+export { default as remainedTimeFormat } from './remainedTimeFormat';

--- a/utils/priceFormat.ts
+++ b/utils/priceFormat.ts
@@ -1,0 +1,8 @@
+const priceFormat = (price: number) => {
+  const numeralReg = new RegExp(/\B(?=(\d{3})+(?!\d))/g);
+  const numericValueOnly = price.toString().replaceAll(',', '');
+
+  return numericValueOnly.replace(numeralReg, ',');
+};
+
+export default priceFormat;

--- a/utils/remainedTimeFormat.ts
+++ b/utils/remainedTimeFormat.ts
@@ -1,0 +1,13 @@
+import { intervalToDuration, formatDuration } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+const remainedTimeFormat = (expiredTime: Date) => {
+  const remainedTime = intervalToDuration({
+    start: new Date(),
+    end: new Date(expiredTime),
+  });
+
+  return formatDuration(remainedTime, { locale: ko });
+};
+
+export default remainedTimeFormat;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- 상품 상세페이지 상품 조회 기능 구현과 API 연동
- 서버에서 바로 데이터를 가져와서 뿌려주는 작업 진행하였습니다.

# 작업 진행 사항
<img width="400" alt="image" src="https://user-images.githubusercontent.com/50071076/182780138-2fe60f30-3d5f-46d7-adab-e76380531b38.png">

# 관련 이슈
- `GoBackIcon` props에 색 변경하는 기능 추가해야합니다.
- 남은 시간이 실시간으로 변경되도록 반영해야합니다.
- 내가 올린 상품일 경우에 입찰하기 버튼 disabled처리 해줘야 합니다.
- Seller(판매자) 프로필 클릭 시 판매자 정보 (유저페이지)로 이동하도록 구현해야합니다!

# 중점적으로 봐줬으면 하는 부분
- 파일명 봐주시면 감사하겠습니다
- 타입스크립트를 처음 접해봤기 때문에 이슈가 있을 것 같습니다.  확인 부탁드립니다!

실행해보시게 된다면 `/products/1`페이지에서 확인 부탁드립니다!
그리고 `date-fns`모듈 설치 필요합니다! 감사합니다!