### PR TITLE
[BM-209] 메인페이지 로그인 토큰 유무에 따른 레이아웃 구현

### DIFF
--- a/components/Main/LoginButton.tsx
+++ b/components/Main/LoginButton.tsx
@@ -1,0 +1,21 @@
+import { Button } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+
+const LoginButton = () => {
+  const router = useRouter();
+
+  return (
+    <Button
+      border="1px"
+      borderColor="brand.primary-900"
+      backgroundColor="white"
+      color="brand.primary-900"
+      _hover={{ bg: 'brand.primary-100' }}
+      onClick={() => router.push('/login')}
+    >
+      로그인
+    </Button>
+  );
+};
+
+export default LoginButton;

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -1,14 +1,28 @@
 import { Image } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
 
+import { getItem } from 'apis/utils/storage';
 import { Header, SideBar } from 'components/common';
 
-const MainHeader = () => (
-  <Header
-    leftContent={
-      <Image src="/svg/bidMarket.svg" alt="bidmarket" height="20px" />
+import LoginButton from './LoginButton';
+
+const MainHeader = () => {
+  const [isLogin, setIsLogin] = useState(false);
+
+  useEffect(() => {
+    if (getItem('token')) {
+      setIsLogin(true);
     }
-    rightContent={<SideBar />}
-  ></Header>
-);
+  }, []);
+
+  return (
+    <Header
+      leftContent={
+        <Image src="/svg/bidMarket.svg" alt="bidmarket" height="20px" />
+      }
+      rightContent={isLogin ? <SideBar /> : <LoginButton />}
+    ></Header>
+  );
+};
 
 export default MainHeader;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- 메인페이지 로그인 토큰 유무에 따른 레이아웃 구현
- 디테일한 작업이 아닌 헤더에 토큰이 있는 경우와 없는 경우에 따라서 레이아웃이 변경되도록 하였습니다.

# 작업 진행 사항
### 로그인 하지 않았을 경우
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/182831525-8a47c4d8-9b89-4675-a427-7171fb78d0ee.png">

### 로그인 했을 경우
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/182831578-4c37f94d-44df-41e0-b4ce-c21d19248035.png">

# 관련 이슈
- 앞으로 전역에 저장, 혹은 react-query를 사용해서 인증 후에 구현해야합니다. 임시로 데모데이 때 보여줄 화면을 위해 만들었습니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.