### PR TITLE
[BM-210] 경매가 종료된 상품에 대한 예외 버그 픽스

### DIFF
--- a/utils/remainedTimeFormat.ts
+++ b/utils/remainedTimeFormat.ts
@@ -1,10 +1,19 @@
 import { intervalToDuration, formatDuration } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
+const BID_FINISHED = '이미 경매가 종료된 상품입니다';
+
 const remainedTimeFormat = (expiredTime: Date) => {
+  const currentTime = new Date();
+  expiredTime = new Date(expiredTime);
+
+  if (expiredTime < currentTime) {
+    return BID_FINISHED;
+  }
+
   const remainedTime = intervalToDuration({
-    start: new Date(),
-    end: new Date(expiredTime),
+    start: currentTime,
+    end: expiredTime,
   });
 
   return formatDuration(remainedTime, { locale: ko });


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- 만료날짜가 이미 지난 상품에 대해서 버그가 발생하여 수정하였습니다.

# 작업 진행 사항
- 만료된 남은 시간 표시
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/182836794-fd48614b-4f8e-453b-8d53-73a390db8614.png">


# 관련 이슈
없습니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.