### PR TITLE
[BM-171] 회원 정보페이지 API 연동 및 분기처리

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -1,0 +1,10 @@
+import { authInstance } from 'apis/utils/authInstance';
+import { baseInstance } from 'apis/utils/baseInstance';
+import { User } from 'types/user';
+
+const userAPI = {
+  getAuthUser: () => authInstance.get<User>('users/auth'),
+  getUser: (encodedId: string) => baseInstance.get<User>(`/users/${encodedId}`),
+};
+
+export default userAPI;

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -82,7 +82,7 @@ const UserId: NextPage = ({
             fontStyle="normal"
             color="barnd.dark"
           >
-            {isMyPage ? '마이페이지' : username}
+            {isMyPage ? '마이페이지' : ''}
           </Text>
         }
         rightContent={<SideBar />}

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -1,7 +1,13 @@
-import { Divider, Flex, Text } from '@chakra-ui/react';
-import type { NextPage } from 'next';
+import { Center, Divider, Flex, Spinner, Text } from '@chakra-ui/react';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
+import userAPI from 'apis/api/user';
 import { GoBackIcon, Header, SEO, SideBar } from 'components/common';
 import {
   ProductMenuList,
@@ -9,15 +15,58 @@ import {
   UserProfileInformation,
 } from 'components/User';
 
-const UserId: NextPage = () => {
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { userId } = context.query;
+  let user = {};
+
+  try {
+    const { data } = await userAPI.getUser(userId as string);
+
+    user = data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+    },
+  };
+};
+
+const UserId: NextPage = ({
+  user: { encodedId, thumbnailImg, username },
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
   const { userId } = router.query;
-  // TODO: url의 id와 로그인 중인 id를 비교해서 마이 페이지인지 사용자 페이지 확인
-  const isMyPage = true;
-  const dummyProfile = {
-    nickname: '물안경',
-    profileImageUrl: 'https://bit.ly/code-beast',
-  };
+  const [authUserId, setAuthUserId] = useState('');
+  const isMyPage = encodedId === authUserId;
+
+  useEffect(() => {
+    if (!encodedId) {
+      router.replace('/404');
+    }
+  }, [encodedId, router]);
+
+  useEffect(() => {
+    const fetchAuthUser = async () => {
+      const {
+        data: { encodedId },
+      } = await userAPI.getAuthUser();
+
+      setAuthUserId(encodedId);
+    };
+
+    fetchAuthUser();
+  }, []);
+
+  if (!encodedId) {
+    return (
+      <Center height="100%">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
 
   return (
     <>
@@ -33,15 +82,15 @@ const UserId: NextPage = () => {
             fontStyle="normal"
             color="barnd.dark"
           >
-            {isMyPage ? '마이페이지' : '사용자 닉네임'}
+            {isMyPage ? '마이페이지' : username}
           </Text>
         }
         rightContent={<SideBar />}
       ></Header>
       <Flex width="100%" flexDirection="column" gap="29px">
         <UserProfileInformation
-          profileImageUrl={dummyProfile.profileImageUrl}
-          nickname={dummyProfile.nickname}
+          profileImageUrl={thumbnailImg}
+          nickname={username}
         />
         {isMyPage ? (
           <UserProfileEditButton


### PR DESCRIPTION
잘못된 userId 경로일 때는 404로 리다이렉트.

# 🧑‍💻 작업 내용(개요)
회원 정보페이지 API 연동 및 분기처리

# 작업 진행 사항

https://user-images.githubusercontent.com/16220817/182881630-bddbabaf-84d0-4396-a38b-19fbbf646ff9.mov

회원 정보페이지 API 연동
- 페이지 접속시 `userId`(`encodedId`) 기준으로 정보 받아옴.
- 로컬에 있는 `token`을 기준으로 정보 로그인 유저 정보 받아옴.


분기처리
- `url` 기준으로 받아온 `id`와 `token` 기준으로 받아온 id를 비교해서 검증.
- `url` 의 id가 잘못됐으면 404페이지로 전달.

# 관련 이슈
로그인시 배포주소로 리다이렉트 중.
  - (영상찍으려 그런걸까요?)
  - 원래 요청한 주소로 리다이렉트를 해줘야 테스트도 편할 것 같습니다.
  - 수동으로 토큰 긁어와야합니다 ㅠ

잘못된 url(`userId`)에 대한 처리 필요할지?
  - 일단 404로 리다이렉트

`token`을 활용해서 받아오는 유저정보는 SSR 어려울듯
  - 로컬에 저장된 걸 `getItem` 해오는데 `window`에 접근 불가.

# 중점적으로 봐줬으면 하는 부분
api 네이밍 고민
  - `getAuthUser`로 일단 작성했는데 적절한 이름이 생각나지 않습니다. (`token`으로 유저정보 가져오는 api)