### PR TITLE
[BM-63] API를 통해 유저 정보를 변경

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -5,6 +5,8 @@ import { User } from 'types/user';
 const userAPI = {
   getAuthUser: () => authInstance.get<User>('users/auth'),
   getUser: (encodedId: string) => baseInstance.get<User>(`/users/${encodedId}`),
+  updateUser: (username: string, profileImageUrl: string) =>
+    authInstance.patch('users', { username, profileImageUrl }),
 };
 
 export default userAPI;

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -34,8 +34,7 @@ const EditProfileForm = ({
 
       toast({
         position: 'top',
-        title: '변경 완료',
-        description: '프로필 정보가 변경 됐습니다.',
+        title: '프로필 변경 완료',
         status: 'success',
         duration: 1500,
         isClosable: true,

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,4 +1,9 @@
-import { Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
+import {
+  Flex,
+  FormControl,
+  FormErrorMessage,
+  useToast,
+} from '@chakra-ui/react';
 import { useState } from 'react';
 
 import userAPI from 'apis/api/user';
@@ -26,6 +31,15 @@ const EditProfileForm = ({
       await userAPI.updateUser(nickname, profileImageUrl);
       setPrevNickname(nickname);
       setPrevProfileImage(profileImageUrl);
+
+      toast({
+        position: 'top',
+        title: '변경 완료',
+        description: '프로필 정보가 변경 됐습니다.',
+        status: 'success',
+        duration: 1500,
+        isClosable: true,
+      });
     },
     validate: ({ nickname, profileImage }) => {
       const error: { nickname?: string } = {};
@@ -41,6 +55,7 @@ const EditProfileForm = ({
       return error;
     },
   });
+  const toast = useToast();
 
   // TODO: error(빈값, 길이제한?, 닉네임 정의 필요) 적절하게 렌더링 해주기. (글자 vs 모달)
   return (

--- a/components/ProfileEdit/EditForm.tsx
+++ b/components/ProfileEdit/EditForm.tsx
@@ -1,6 +1,7 @@
 import { Flex, FormControl, FormErrorMessage } from '@chakra-ui/react';
 import { useState } from 'react';
 
+import userAPI from 'apis/api/user';
 import useForm from 'hooks/useForm';
 
 import { NicknameInput, SubmitButton } from '.';
@@ -19,21 +20,12 @@ const EditProfileForm = ({
   const [prevProfileImage, setPrevProfileImage] = useState(profileImageUrl);
   const { errors, isLoading, handleChange, handleSubmit } = useForm({
     initialValues: { nickname, profileImage: profileImageUrl },
-    // TODO: api로 닉네임, 사진(S3 주소값??) 보내주기
     onSubmit: async ({ nickname, e }) => {
-      const fakeSubmit = () =>
-        new Promise((resolve) => {
-          setTimeout(() => {
-            alert(
-              `onSubmit!\n nickname: ${nickname} \n profileImage: ${e.target.profileImage.dataset.uploadedurl}`
-            );
-            resolve('Success');
-          }, 1500);
-        });
+      const profileImageUrl = e.target.profileImage.dataset.uploadedurl;
 
-      await fakeSubmit();
+      await userAPI.updateUser(nickname, profileImageUrl);
       setPrevNickname(nickname);
-      setPrevProfileImage(e.target.profileImage.value);
+      setPrevProfileImage(profileImageUrl);
     },
     validate: ({ nickname, profileImage }) => {
       const error: { nickname?: string } = {};

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -3,9 +3,9 @@ import { useEffect, useState } from 'react';
 import userAPI from 'apis/api/user';
 
 const useLoginUser = () => {
-  const [authUserId, setAuthUserId] = useState('');
-  const [profileImage, setProfileImage] = useState('');
-  const [nickname, setNickname] = useState('');
+  const [authUserId, setAuthUserId] = useState<string | undefined>('');
+  const [profileImage, setProfileImage] = useState<string | undefined>('');
+  const [nickname, setNickname] = useState<string | undefined>('');
 
   useEffect(() => {
     setAuthUserInformation();
@@ -22,6 +22,10 @@ const useLoginUser = () => {
       setNickname(username);
     } catch (e) {
       console.error(e);
+
+      setAuthUserId(undefined);
+      setProfileImage(undefined);
+      setNickname(undefined);
     }
   };
 

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+import userAPI from 'apis/api/user';
+
+const useLoginUser = () => {
+  const [authUserId, setAuthUserId] = useState('');
+  const [profileImage, setProfileImage] = useState('');
+
+  useEffect(() => {
+    setAuthUserInformation();
+  }, []);
+
+  const setAuthUserInformation = async () => {
+    try {
+      const { encodedId, thumbnailImg } = (await userAPI.getAuthUser()).data;
+
+      setAuthUserId(encodedId);
+      setProfileImage(thumbnailImg);
+    } catch (e) {
+      console.error(e);
+    }
+  };
+
+  return { authUserId, profileImage };
+};
+
+export default useLoginUser;

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -5,6 +5,7 @@ import userAPI from 'apis/api/user';
 const useLoginUser = () => {
   const [authUserId, setAuthUserId] = useState('');
   const [profileImage, setProfileImage] = useState('');
+  const [nickname, setNickname] = useState('');
 
   useEffect(() => {
     setAuthUserInformation();
@@ -12,16 +13,19 @@ const useLoginUser = () => {
 
   const setAuthUserInformation = async () => {
     try {
-      const { encodedId, thumbnailImg } = (await userAPI.getAuthUser()).data;
+      const { encodedId, thumbnailImg, username } = (
+        await userAPI.getAuthUser()
+      ).data;
 
       setAuthUserId(encodedId);
       setProfileImage(thumbnailImg);
+      setNickname(username);
     } catch (e) {
       console.error(e);
     }
   };
 
-  return { authUserId, profileImage };
+  return { authUserId, profileImage, nickname };
 };
 
 export default useLoginUser;

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -1,15 +1,79 @@
-import { Flex } from '@chakra-ui/react';
-import type { NextPage } from 'next';
+import { Center, Flex, Spinner } from '@chakra-ui/react';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
+import userAPI from 'apis/api/user';
 import { SEO } from 'components/common';
 import { ProfileEditHeader } from 'components/ProfileEdit';
 import EditProfileForm from 'components/ProfileEdit/EditForm';
 
-const Edit: NextPage = () => {
-  const dummyProps = {
-    nickname: '물안경',
-    profileImageUrl: 'https://bit.ly/code-beast',
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { userId } = context.query;
+  let user = {};
+
+  try {
+    const { data } = await userAPI.getUser(userId as string);
+
+    user = data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+    },
   };
+};
+
+const Edit: NextPage = ({
+  user: { encodedId, thumbnailImg, username },
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const router = useRouter();
+  const [authUserId, setAuthUserId] = useState('');
+
+  useEffect(() => {
+    if (!encodedId) {
+      router.replace('/');
+
+      return;
+    }
+
+    if (!authUserId) {
+      return;
+    }
+
+    if (encodedId !== authUserId) {
+      router.replace('/');
+
+      return;
+    }
+  }, [encodedId, authUserId, router]);
+
+  useEffect(() => {
+    const fetchAuthUser = async () => {
+      const {
+        data: { encodedId },
+      } = await userAPI.getAuthUser();
+
+      setAuthUserId(encodedId);
+    };
+
+    fetchAuthUser();
+  }, []);
+
+  if (!authUserId || authUserId !== encodedId) {
+    return (
+      <Center height="100%">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
 
   return (
     <>
@@ -17,7 +81,7 @@ const Edit: NextPage = () => {
       <Flex flexDirection="column" width="100%" height="100%">
         <ProfileEditHeader />
         <Flex width="100%" height="100%" marginTop="48px">
-          <EditProfileForm {...dummyProps} />
+          <EditProfileForm nickname={username} profileImageUrl={thumbnailImg} />
         </Flex>
       </Flex>
     </>

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -18,9 +18,7 @@ export const getServerSideProps: GetServerSideProps = async (context) => {
   let user = {};
 
   try {
-    const { data } = await userAPI.getUser(userId as string);
-
-    user = data;
+    user = (await userAPI.getUser(userId as string)).data;
   } catch (error) {
     console.error(error);
   }

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -39,7 +39,7 @@ const Edit: NextPage = ({
   const { authUserId } = useLoginUser();
 
   useEffect(() => {
-    if (!authUserId) {
+    if (authUserId === '') {
       return;
     }
 

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -39,17 +39,11 @@ const Edit: NextPage = ({
   const { authUserId } = useLoginUser();
 
   useEffect(() => {
-    if (!encodedId) {
-      router.replace('/');
-
-      return;
-    }
-
     if (!authUserId) {
       return;
     }
 
-    if (encodedId !== authUserId) {
+    if (!encodedId || encodedId !== authUserId) {
       router.replace('/');
 
       return;

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -5,12 +5,13 @@ import type {
   NextPage,
 } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import userAPI from 'apis/api/user';
 import { SEO } from 'components/common';
 import { ProfileEditHeader } from 'components/ProfileEdit';
 import EditProfileForm from 'components/ProfileEdit/EditForm';
+import useLoginUser from 'hooks/useLoginUser';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { userId } = context.query;
@@ -35,7 +36,7 @@ const Edit: NextPage = ({
   user: { encodedId, thumbnailImg, username },
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
-  const [authUserId, setAuthUserId] = useState('');
+  const { authUserId } = useLoginUser();
 
   useEffect(() => {
     if (!encodedId) {
@@ -54,18 +55,6 @@ const Edit: NextPage = ({
       return;
     }
   }, [encodedId, authUserId, router]);
-
-  useEffect(() => {
-    const fetchAuthUser = async () => {
-      const {
-        data: { encodedId },
-      } = await userAPI.getAuthUser();
-
-      setAuthUserId(encodedId);
-    };
-
-    fetchAuthUser();
-  }, []);
 
   if (!authUserId || authUserId !== encodedId) {
     return (


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
API를 통해 유저 정보를 변경

# 작업 진행 사항

https://user-images.githubusercontent.com/16220817/183102584-8a6e8d4c-0152-432a-af55-cf62a5e2aa0b.mov

- api로 유저정보 받아와서 렌더링
- 본인이 아니면 home으로 리다이렉트
- api로 변경 사항 전송
- toast로 완료 메세지 표시

# 관련 이슈
- home으로 리다이렉트시 콘솔에 에러 찍힘
  - `Error: Abort fetching component for route: "/"`

- Auth 스피너 계속 사용중인데 공통으로 빼도 좋을 것 같습니다.

- 일단 fetch 다시 사용했습니다.
  - user 정보를 api에서 받아오고 추가로 그 값을 변수 할당.
  - 받아오기만 한다면 `get` 같은 접두어가 더 잘어울릴수도? 
  - 더 사용안해서 익명함수가 깔끔할 수도 있겠지만 명시적으로 이름을 부여하면 조금더 직관적으로 알 것 같음.
  - 컨벤션 정해지면 그대로 따라가겠습니다. 

- api 파라미터 객체로 넘기기?
  - 객체로 넘기면 순서 상관 없이 작성, 사용하는 쪽에서 프로퍼티명을 작성해서 어떤 값이 넘어가는지 알기 쉬움.
  - 파라미터가 1개, 2개라 굳이 객체로 안해도 될 것 같기도.

# 중점적으로 봐줬으면 하는 부분
- 접근 권한 확인하는 로직이 길어진 것 같은데 적절한지 궁금합니다.
- toast 디자인
  - 일단 그대로 사용.
  - 아래서 올라오면 완료 버튼 가려지고 위에서 내려오면 헤더 부분 가려짐.
  - 예전에 위로 결정했던걸로 기억해서 위에서 내려오도록 설정.