### PR TITLE
[BM-184] 메인페이지 header 사용자 프로필이미지로 변경

### DIFF
--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -15,19 +15,19 @@ const MainHeader = () => {
   const [userId, setUserId] = useState('');
 
   useEffect(() => {
+    setLoginUserProfile();
+  }, []);
+
+  const setLoginUserProfile = async () => {
     try {
-      (async () => {
-        const {
-          data: { thumbnailImg, encodedId },
-        } = await userAPI.getAuthUser();
-        setProfileImageUrl(thumbnailImg);
-        setUserId(encodedId);
-      })();
+      const { encodedId, thumbnailImg } = (await userAPI.getAuthUser()).data;
+      setProfileImageUrl(thumbnailImg);
+      setUserId(encodedId);
       setIsLogin(true);
     } catch (error) {
       console.log(error);
     }
-  }, []);
+  };
 
   return (
     <Header

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -1,17 +1,31 @@
-import { Image } from '@chakra-ui/react';
+import { BellIcon } from '@chakra-ui/icons';
+import { Avatar, Circle, Flex, Image } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
-import { getItem } from 'apis/utils/storage';
-import { Header, SideBar } from 'components/common';
+import userAPI from 'apis/api/user';
+import { Header } from 'components/common';
 
 import LoginButton from './LoginButton';
 
 const MainHeader = () => {
+  const router = useRouter();
   const [isLogin, setIsLogin] = useState(false);
+  const [profileImageUrl, setProfileImageUrl] = useState('');
+  const [userId, setUserId] = useState('');
 
   useEffect(() => {
-    if (getItem('token')) {
+    try {
+      (async () => {
+        const {
+          data: { thumbnailImg, encodedId },
+        } = await userAPI.getAuthUser();
+        setProfileImageUrl(thumbnailImg);
+        setUserId(encodedId);
+      })();
       setIsLogin(true);
+    } catch (error) {
+      console.log(error);
     }
   }, []);
 
@@ -20,7 +34,23 @@ const MainHeader = () => {
       leftContent={
         <Image src="/svg/bidMarket.svg" alt="bidmarket" height="20px" />
       }
-      rightContent={isLogin ? <SideBar /> : <LoginButton />}
+      rightContent={
+        isLogin ? (
+          <Flex gap="10px" alignItems="center">
+            <BellIcon w="32px" h="32px" _hover={{ cursor: 'pointer' }} />
+            <Circle
+              border="2px solid"
+              borderColor="brand.primary-900"
+              _hover={{ cursor: 'pointer' }}
+              onClick={() => router.push(`/user/${userId}`)}
+            >
+              <Avatar name="프로필 이미지" size="sm" src={profileImageUrl} />
+            </Circle>
+          </Flex>
+        ) : (
+          <LoginButton />
+        )
+      }
     ></Header>
   );
 };

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import userAPI from 'apis/api/user';
+import { getItem } from 'apis/utils/storage';
 import { Header } from 'components/common';
 
 import LoginButton from './LoginButton';
@@ -15,12 +16,15 @@ const MainHeader = () => {
   const [userId, setUserId] = useState('');
 
   useEffect(() => {
-    setLoginUserProfile();
+    if (getItem('token')) {
+      setLoginUserStatus();
+    }
   }, []);
 
-  const setLoginUserProfile = async () => {
+  const setLoginUserStatus = async () => {
     try {
       const { encodedId, thumbnailImg } = (await userAPI.getAuthUser()).data;
+
       setProfileImageUrl(thumbnailImg);
       setUserId(encodedId);
       setIsLogin(true);


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 메인페이지 header에서 `hamburger` -> `사용자 프로필이미지` 로 변경
   - [x] 프로필 이미지를 누르면 회원 정보 페이지로 넘어갑니다. 
- [x] 알림 아이콘 추가 (figma의 아이콘이 chakra-ui의 아이콘에 없어서 대체 사용)

# 작업 진행 사항
<img width="764" alt="image" src="https://user-images.githubusercontent.com/75886763/183108655-503cf242-94f4-4cde-90cb-4de633f2bafc.png">

# 관련 이슈
- 없습니다.
- 향후 알림페이지도 연결 예정입니다.

# 중점적으로 봐줬으면 하는 부분
- 함수명, 변수명, 클린 코드를 위해 확인 부탁드립니다.