### PR TITLE
[BM-256] useLoginUser 훅 개선과 바뀐 API 명세 반영

### DIFF
--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -1,5 +1,5 @@
 import { BellIcon } from '@chakra-ui/icons';
-import { Avatar, Badge, Circle, Flex, Image } from '@chakra-ui/react';
+import { Avatar, Circle, Flex, Image } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -13,7 +13,7 @@ const MainHeader = () => {
   const router = useRouter();
   const [isLogin, setIsLogin] = useState(false);
   const [profileImageUrl, setProfileImageUrl] = useState('');
-  const [userId, setUserId] = useState('');
+  const [userId, setUserId] = useState(-1);
 
   useEffect(() => {
     if (getItem('token')) {

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -1,5 +1,5 @@
 import { BellIcon } from '@chakra-ui/icons';
-import { Avatar, Circle, Flex, Image } from '@chakra-ui/react';
+import { Avatar, Badge, Circle, Flex, Image } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
@@ -23,10 +23,10 @@ const MainHeader = () => {
 
   const setLoginUserStatus = async () => {
     try {
-      const { encodedId, thumbnailImg } = (await userAPI.getAuthUser()).data;
+      const { id, profileImage } = (await userAPI.getAuthUser()).data;
 
-      setProfileImageUrl(thumbnailImg);
-      setUserId(encodedId);
+      setProfileImageUrl(profileImage);
+      setUserId(id);
       setIsLogin(true);
     } catch (error) {
       console.log(error);

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -16,8 +16,8 @@ import { priceFormat, remainedTimeFormat } from 'utils';
 import ProductBidProgress from './ProductBidDrawer';
 
 interface ProductBidProps {
-  writerId: string;
-  authUserId: string;
+  writerId: number;
+  authUserId: number;
   minimumPrice: number;
   expireAt: Date;
 }
@@ -38,7 +38,7 @@ const ProductBid = ({
   }, [remainedTime]);
 
   const handleBidButtonClick = () => {
-    if (!authUserId) {
+    if (authUserId === -1) {
       toast({
         position: 'top',
         title: '입찰은 로그인 후 이용 가능합니다.',

--- a/components/ProductDetail/ProductSeller.tsx
+++ b/components/ProductDetail/ProductSeller.tsx
@@ -2,12 +2,12 @@ import { Flex, Box, Image, Text } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 
 interface ProductSellerProps {
-  userId: string;
+  userId: number;
   name: string;
-  thumbnailImg: string;
+  profileImage: string;
 }
 
-const ProductSeller = ({ userId, name, thumbnailImg }: ProductSellerProps) => {
+const ProductSeller = ({ userId, name, profileImage }: ProductSellerProps) => {
   const router = useRouter();
 
   return (
@@ -18,7 +18,7 @@ const ProductSeller = ({ userId, name, thumbnailImg }: ProductSellerProps) => {
       <Flex alignItems="center">
         <Image
           alt="profile-image"
-          src={thumbnailImg}
+          src={profileImage}
           w="45px"
           h="45px"
           borderRadius="50%"

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -1,33 +1,36 @@
 import { useEffect, useState } from 'react';
 
-import userAPI from 'apis/api/user';
+import { userAPI } from 'apis';
+import { getItem } from 'apis/utils/storage';
+import { User } from 'types/user';
 
 const useLoginUser = () => {
-  const [authUserId, setAuthUserId] = useState<number | undefined>(-1);
-  const [profileImage, setProfileImage] = useState<string | undefined>('');
-  const [nickname, setNickname] = useState<string | undefined>('');
+  const [userInfo, setUserInfo] = useState<User>({
+    id: -1,
+    username: '',
+    profileImage: '',
+  });
 
   useEffect(() => {
+    if (!getItem('token')) {
+      return;
+    }
+
     setAuthUserInformation();
   }, []);
 
   const setAuthUserInformation = async () => {
     try {
-      const { id, profileImage, username } = (await userAPI.getAuthUser()).data;
-
-      setAuthUserId(id);
-      setProfileImage(profileImage);
-      setNickname(username);
+      const { data } = await userAPI.getAuthUser();
+      setUserInfo(data);
     } catch (e) {
       console.error(e);
 
-      setAuthUserId(undefined);
-      setProfileImage(undefined);
-      setNickname(undefined);
+      setUserInfo({} as User);
     }
   };
 
-  return { authUserId, profileImage, nickname };
+  return { ...userInfo };
 };
 
 export default useLoginUser;

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -30,7 +30,7 @@ const useLoginUser = () => {
     }
   };
 
-  return { ...userInfo };
+  return userInfo;
 };
 
 export default useLoginUser;

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -12,6 +12,7 @@ import {
   ProductInfo,
   ProductSeller,
 } from 'components/ProductDetail';
+import useLoginUser from 'hooks/useLoginUser';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { productId } = context.query;
@@ -37,24 +38,7 @@ const ProductDetail = ({
     createdAt,
   },
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const [authUserId, setAuthUserId] = useState('');
-
-  useEffect(() => {
-    setAuthUserInfo();
-  }, []);
-
-  const setAuthUserInfo = async () => {
-    try {
-      if (!getItem('token')) {
-        return;
-      }
-
-      const { encodedId } = (await userAPI.getAuthUser()).data;
-      setAuthUserId(encodedId);
-    } catch (error) {
-      console.log(error);
-    }
-  };
+  const { id: authUserId } = useLoginUser();
 
   return (
     <>
@@ -69,9 +53,9 @@ const ProductDetail = ({
       <Flex direction="column" width="100%" marginTop="317px">
         <Flex justifyContent="space-between" alignItems="center">
           <ProductSeller
-            userId={writer.encodedId}
+            userId={writer.id}
             name={writer.username}
-            thumbnailImg={writer.thumbnailImg}
+            profileImage={writer.profileImage}
           />
           <StarIcon w="23px" color="brand.primary-900" />
         </Flex>
@@ -85,7 +69,7 @@ const ProductDetail = ({
           expireAt={expireAt}
         />
         <ProductBid
-          writerId={writer.encodedId}
+          writerId={writer.id}
           authUserId={authUserId}
           minimumPrice={minimumPrice}
           expireAt={expireAt}

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -1,10 +1,8 @@
 import { StarIcon } from '@chakra-ui/icons';
 import { Divider, Flex, Box } from '@chakra-ui/react';
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
-import { useEffect, useState } from 'react';
 
-import { productAPI, userAPI } from 'apis';
-import { getItem } from 'apis/utils/storage';
+import { productAPI } from 'apis';
 import { GoBackIcon, SEO } from 'components/common';
 import {
   ProductBid,

--- a/pages/user/[userId]/edit/index.tsx
+++ b/pages/user/[userId]/edit/index.tsx
@@ -34,7 +34,7 @@ const Edit: NextPage = ({
   user: { id, profileImage, username },
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
-  const { authUserId } = useLoginUser();
+  const { id: authUserId } = useLoginUser();
 
   useEffect(() => {
     if (authUserId === -1) {

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -50,9 +50,7 @@ const UserId: NextPage = ({
 
   useEffect(() => {
     const fetchAuthUser = async () => {
-      const {
-        data: { id },
-      } = await userAPI.getAuthUser();
+      const { id } = (await userAPI.getAuthUser()).data;
 
       setAuthUserId(id);
     };


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 유저 정보 id, username, profileImage로 바뀐 API 명세 반영
- [x]  useLoginUser 훅 개선
- [x]  id, username, profileImage 를 state에 각각 저장하던 부분을 User이라는 state로 반영함
- [x] 상품 상세 페이지에 useLoginUser 훅 적용
- [x] 토큰이 없을 경우에는 API 자체를 호출하지 않도록 개선 

# 작업 진행 사항
```js
const { data } = await userAPI.getAuthUser();
setUserInfo(data);
```
데이터를 받아와 한번에 userInfo에 저장하였습니다.

# 관련 이슈
- 상품 상세 페이지에 useLoginUser 훅 적용
```ts
// 원래 코드
 const [authUserId, setAuthUserId] = useState('');

  useEffect(() => {
    setAuthUserInfo();
  }, []);

  const setAuthUserInfo = async () => {
    try {
      if (!getItem('token')) {
        return;
      }

      const { encodedId } = (await userAPI.getAuthUser()).data;
      setAuthUserId(encodedId);
    } catch (error) {
      console.log(error);
    }
  };
```
- 반영한 코드
```ts
// 변경 후 코드
 const { id: authUserId } = useLoginUser();
```
- 이제 매우 간단하게 구현됩니다. 훅으로 빼주신 스톤에게 감사의 말씀 드립니다!
- 메인 페이지에도 바로 반영부탁드립니다!

# 중점적으로 봐줬으면 하는 부분
- 개선점이 있을지 검토 부탁드립니다!