### PR TITLE
[BM-230] 변경된 회원 정보 페이지 레이아웃 반영

### DIFF
--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -1,4 +1,3 @@
-import { ChevronRightIcon } from '@chakra-ui/icons';
 import { Flex, Divider, Text, Image } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 
@@ -21,23 +20,36 @@ const ProductMenuItem = ({
     <>
       <Flex
         width="100%"
+        flexDirection="column"
         alignItems="center"
-        gap="17px"
+        gap="13px"
         onClick={() => router.push(routingUrl)}
       >
-        <Image src={iconUrl} alt={`${title} 아이콘`} />
+        <Image
+          width="33.92px"
+          height="38px"
+          src={iconUrl}
+          alt={`${title} 아이콘`}
+        />
         <Text
           flexGrow="1"
+          color="#2E2E2E"
           fontFamily="Roboto"
           fontStyle="normal"
           fontWeight="400"
-          fontSize="16"
+          fontSize="14"
+          lineHeight="128.19%"
         >
           {title}
         </Text>
-        <ChevronRightIcon justifySelf="flex-end" />
       </Flex>
-      {!isLastItem ? <Divider /> : undefined}
+      {!isLastItem ? (
+        <Divider
+          orientation="vertical"
+          border="3px solid #EFEFEF"
+          height="20px"
+        />
+      ) : undefined}
     </>
   );
 };

--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -33,7 +33,7 @@ const ProductMenuItem = ({
         />
         <Text
           flexGrow="1"
-          color="#2E2E2E"
+          color="brand.dark"
           fontFamily="Roboto"
           fontStyle="normal"
           fontWeight="400"

--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -43,13 +43,13 @@ const ProductMenuItem = ({
           {title}
         </Text>
       </Flex>
-      {!isLastItem ? (
+      {!isLastItem && (
         <Divider
           orientation="vertical"
           border="3px solid #EFEFEF"
           height="20px"
         />
-      ) : undefined}
+      )}
     </>
   );
 };

--- a/components/User/ProductMenuList.tsx
+++ b/components/User/ProductMenuList.tsx
@@ -11,12 +11,12 @@ const ProductMenuList = ({ userId }: ProductMenuListProps) => {
   const productMenu = [
     {
       iconUrl: '/svg/sellProductMenuIcon.svg',
-      title: '판매한 상품',
+      title: '판매 상품',
       routingUrl: `./${userId}/products/sell`,
     },
     {
       iconUrl: '/svg/bidProductMenuIcon.svg',
-      title: '입찰한 상품',
+      title: '입찰 상품',
       routingUrl: `./${userId}/products/bid`,
     },
     {
@@ -27,7 +27,13 @@ const ProductMenuList = ({ userId }: ProductMenuListProps) => {
   ];
 
   return (
-    <Flex width="100%" direction="column" gap="12px" marginTop="21px">
+    <Flex
+      width="100%"
+      justifyContent="center"
+      alignItems="center"
+      gap="12px"
+      marginTop="21px"
+    >
       {productMenu.map((currentMenu, index) => (
         <Fragment key={index}>
           <ProductMenuItem

--- a/components/User/UserSetting.tsx
+++ b/components/User/UserSetting.tsx
@@ -25,7 +25,7 @@ const UserSetting = () => {
         cursor="pointer"
         onClick={() => {
           removeItem('token');
-          router.reload();
+          router.push('/');
         }}
       >
         <Img src="/svg/logout.svg" />

--- a/components/User/UserSetting.tsx
+++ b/components/User/UserSetting.tsx
@@ -1,0 +1,38 @@
+import { Flex, Img, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+
+import { removeItem } from 'apis/utils/storage';
+
+const UserSetting = () => {
+  const router = useRouter();
+
+  return (
+    <Flex flexDirection="column" width="100%" marginTop="21px" gap="19px">
+      <Text
+        textAlign="left"
+        color="brand.dark"
+        fontFamily="Roboto"
+        fontStyle="normal"
+        fontWeight="700"
+        fontSize="16px"
+        lineHeight="128.19%"
+      >
+        계정 설정
+      </Text>
+      <Flex
+        alignItems="center"
+        gap="16px"
+        cursor="pointer"
+        onClick={() => {
+          removeItem('token');
+          router.reload();
+        }}
+      >
+        <Img src="/svg/logout.svg" />
+        <Text>로그아웃</Text>
+      </Flex>
+    </Flex>
+  );
+};
+
+export default UserSetting;

--- a/components/User/index.tsx
+++ b/components/User/index.tsx
@@ -1,3 +1,4 @@
+export { default as UserSetting } from './UserSetting';
 export { default as UserProfileInformation } from './UserProfileInformation';
 export { default as UserProfileEditButton } from './UserProfileEditButton';
 export { default as ProductMenuList } from './ProductMenuList';

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -15,6 +15,7 @@ import {
   UserProfileInformation,
   UserSetting,
 } from 'components/User';
+import useLoginUser from 'hooks/useLoginUser';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { userId } = context.query;
@@ -40,7 +41,7 @@ const UserId: NextPage = ({
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
   const { userId } = router.query;
-  const [authUserId, setAuthUserId] = useState(-1);
+  const { id: authUserId } = useLoginUser();
   const isMyPage = id === authUserId;
 
   useEffect(() => {
@@ -48,16 +49,6 @@ const UserId: NextPage = ({
       router.replace('/404');
     }
   }, [id, router]);
-
-  useEffect(() => {
-    const fetchAuthUser = async () => {
-      const { id } = (await userAPI.getAuthUser()).data;
-
-      setAuthUserId(id);
-    };
-
-    fetchAuthUser();
-  }, []);
 
   if (!id) {
     return (

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -75,7 +75,6 @@ const UserId: NextPage = ({
             {isMyPage ? '마이페이지' : ''}
           </Text>
         }
-        rightContent={<SideBar />}
       />
       <Flex width="100%" flexDirection="column" gap="29px">
         <UserProfileInformation

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -81,11 +81,11 @@ const UserId: NextPage = ({
           profileImageUrl={profileImage}
           nickname={username}
         />
-        {isMyPage ? (
+        {isMyPage && (
           <UserProfileEditButton
             onClick={() => router.push(`./${userId}/edit`)}
           />
-        ) : undefined}
+        )}
       </Flex>
       <ProductMenuList userId={userId as string} />
       {isMyPage ? (

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -13,6 +13,7 @@ import {
   ProductMenuList,
   UserProfileEditButton,
   UserProfileInformation,
+  UserSetting,
 } from 'components/User';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
@@ -84,7 +85,7 @@ const UserId: NextPage = ({
           </Text>
         }
         rightContent={<SideBar />}
-      ></Header>
+      />
       <Flex width="100%" flexDirection="column" gap="29px">
         <UserProfileInformation
           profileImageUrl={profileImage}
@@ -96,8 +97,19 @@ const UserId: NextPage = ({
           />
         ) : undefined}
       </Flex>
-      <Divider height="7px" marginTop="27px" backgroundColor="#F2F2F2" />
       <ProductMenuList userId={userId as string} />
+      {isMyPage ? (
+        <>
+          <Divider
+            width="100%"
+            height="7px"
+            background="#F8F8F8"
+            boxShadow="inset 0px 1px 3px rgba(0, 0, 0, 0.03)"
+            marginTop="25px"
+          />
+          <UserSetting />
+        </>
+      ) : undefined}
     </>
   );
 };

--- a/public/svg/logout.svg
+++ b/public/svg/logout.svg
@@ -1,0 +1,4 @@
+<svg width="18" height="20" viewBox="0 0 18 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M17 19.0001V17.0001C17 15.9393 16.5786 14.9218 15.8284 14.1717C15.0783 13.4216 14.0609 13.0001 13 13.0001H5C3.93913 13.0001 2.92172 13.4216 2.17157 14.1717C1.42143 14.9218 1 15.9393 1 17.0001V19.0001" stroke="#2E2E2E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 9C11.2091 9 13 7.20914 13 5C13 2.79086 11.2091 1 9 1C6.79086 1 5 2.79086 5 5C5 7.20914 6.79086 9 9 9Z" stroke="#2E2E2E" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 변경된 회원 정보 페이지 레이아웃 반영
- [x] 회원 정보 페이지에 `useLoginUser` 적용

# 작업 진행 사항
<img width="360" alt="스크린샷 2022-08-08 오전 12 05 51" src="https://user-images.githubusercontent.com/16220817/183297574-c1f70e35-c2a8-49b2-affa-617ef6b282a9.png">


# 관련 이슈
마이페이지가 아닐 경우에 화면이 조금 허전해 보이기도 합니다.
<img width="361" alt="스크린샷 2022-08-08 오전 12 07 30" src="https://user-images.githubusercontent.com/16220817/183297664-f3ce8cdc-5e0e-428b-8bcf-3b8fbc4c8b85.png">

# 중점적으로 봐줬으면 하는 부분
`UserSetting` 네이밍
- 계정 설정 부분을 `UserSetting으로 만들었는데 적절한 이름일지 궁금합니다.