### PR TITLE
[BM-232] 입찰한 상품 목록 API 연동

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -1,10 +1,25 @@
 import { authInstance } from 'apis/utils/authInstance';
 import { baseInstance } from 'apis/utils/baseInstance';
+import { ProductsResponseType } from 'types/product';
 import { User } from 'types/user';
+
+interface GetBiddingProductsType {
+  offset: number;
+  limit: number;
+  sort?: string;
+}
 
 const userAPI = {
   getAuthUser: () => authInstance.get<User>('users/auth'),
   getUser: (id: number) => baseInstance.get<User>(`/users/${id}`),
+  getBiddingProducts: ({
+    offset,
+    limit,
+    sort = 'END_DATE_ASC',
+  }: GetBiddingProductsType) =>
+    authInstance.get<ProductsResponseType>(
+      `/users/biddings?offset=${offset}&limit=${limit}&sort=${sort}`
+    ),
   updateUser: (username: string, profileImage: string) =>
     authInstance.patch('users', { username, profileImage }),
 };

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -16,6 +16,11 @@ const Bid: NextPage = () => {
     []
   );
   const [offset, setOffset] = useState(0);
+
+  useEffect(() => {
+    getBiddingProducts();
+  }, []);
+
   const getBiddingProducts = async () => {
     try {
       const { data } = await userAPI.getBiddingProducts({
@@ -30,10 +35,6 @@ const Bid: NextPage = () => {
       console.error(error);
     }
   };
-
-  useEffect(() => {
-    getBiddingProducts();
-  }, []);
 
   if (!isLoaded) {
     return (

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -49,7 +49,17 @@ const Bid: NextPage = () => {
       <SEO title="사용자 이름" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={<Text>입찰한 상품</Text>}
+        middleContent={
+          <Text
+            fontFamily="Roboto"
+            fontSize="20px"
+            fontWeight="700"
+            lineHeight="23px"
+            color="barnd.dark"
+          >
+            입찰한 상품
+          </Text>
+        }
       />
       {biddingProducts.length === 0 ? (
         <Center flexDirection="column" height="100%">

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -1,13 +1,48 @@
-import { Center, Text } from '@chakra-ui/react';
+import { DownloadIcon } from '@chakra-ui/icons';
+import { Button, Center, Divider, Spinner, Text } from '@chakra-ui/react';
 import type { NextPage } from 'next';
+import { Fragment, useEffect, useState } from 'react';
 
-import { GoBackIcon, Header, SEO } from 'components/common';
+import { userAPI } from 'apis';
+import { Card, GoBackIcon, Header, SEO } from 'components/common';
 import { NoProducts } from 'components/User';
+import { ProductsResponseType } from 'types/product';
 
-// @ TODO 데이터 가져와서 연결 작업
-const DUMMY = [];
+const LIMIT = 5;
 
 const Bid: NextPage = () => {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [biddingProducts, setBiddingProducts] = useState<ProductsResponseType>(
+    []
+  );
+  const [offset, setOffset] = useState(0);
+  const fetchData = async () => {
+    try {
+      const { data } = await userAPI.getBiddingProducts({
+        offset,
+        limit: LIMIT,
+      });
+
+      setIsLoaded(true);
+      setBiddingProducts([...biddingProducts, ...data]);
+      setOffset(offset + LIMIT);
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  if (!isLoaded) {
+    return (
+      <Center height="100%">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
+
   return (
     <>
       {/* @ TODO 실제 사용자 닉네임으로 교체 예정 */}
@@ -16,12 +51,33 @@ const Bid: NextPage = () => {
         leftContent={<GoBackIcon />}
         middleContent={<Text>입찰한 상품</Text>}
       />
-      {DUMMY.length === 0 ? (
+      {biddingProducts.length === 0 ? (
         <Center flexDirection="column" height="100%">
           <NoProducts pageName="userBidProducts" />
         </Center>
       ) : (
-        <Text>list of Product Cards</Text>
+        <>
+          {biddingProducts.map((product) => {
+            return (
+              <Fragment key={product.id}>
+                <Card productInfo={product} />
+                <Divider />
+              </Fragment>
+            );
+          })}
+          <Button
+            alignSelf="center"
+            w="100px"
+            marginTop="20px"
+            borderRadius="30px"
+            color="white"
+            backgroundColor="brand.primary-900"
+            _hover={{ bg: 'brand.primary-900' }}
+            onClick={() => fetchData()}
+          >
+            <DownloadIcon w="5" h="5" />
+          </Button>
+        </>
       )}
     </>
   );

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -16,7 +16,7 @@ const Bid: NextPage = () => {
     []
   );
   const [offset, setOffset] = useState(0);
-  const fetchData = async () => {
+  const getBiddingProducts = async () => {
     try {
       const { data } = await userAPI.getBiddingProducts({
         offset,
@@ -32,7 +32,7 @@ const Bid: NextPage = () => {
   };
 
   useEffect(() => {
-    fetchData();
+    getBiddingProducts();
   }, []);
 
   if (!isLoaded) {
@@ -83,7 +83,7 @@ const Bid: NextPage = () => {
             color="white"
             backgroundColor="brand.primary-900"
             _hover={{ bg: 'brand.primary-900' }}
-            onClick={() => fetchData()}
+            onClick={getBiddingProducts}
           >
             <DownloadIcon w="5" h="5" />
           </Button>

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -4,7 +4,7 @@ import type { NextPage } from 'next';
 import { Fragment, useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
-import { Card, GoBackIcon, Header, SEO } from 'components/common';
+import { GoBackIcon, Header, ProductCard, SEO } from 'components/common';
 import { NoProducts } from 'components/User';
 import { ProductsResponseType } from 'types/product';
 
@@ -71,7 +71,7 @@ const Bid: NextPage = () => {
           {biddingProducts.map((product) => {
             return (
               <Fragment key={product.id}>
-                <Card productInfo={product} />
+                <ProductCard productInfo={product} />
                 <Divider />
               </Fragment>
             );


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 입찰 상품 목록 API 추가
- [X] 입찰 상품 페이지 API 연동 

# 작업 진행 사항
- 데이터가 없어서 `productApi.getProduct`를 활용했습니다. (`response` 타입이 같음)

https://user-images.githubusercontent.com/16220817/183301748-6b124d0b-b0c0-4b43-8094-1f8b26459e7c.mov


# 관련 이슈
- 입찰 상품 데이터가 없어서 실제 확인은 못했습니다. (빈 배열로 오는건 확인)
- 인증이 필요한(`window.localstorage`) API라 SSR 불가.
- 입찰 상품 배열 길이로 구분시 초기 값이 빈 배열이라 무조건 상품 없음이 됨. 최초 `fetch` 이후 부터 분기 필요.
- BM-233(판매 상품)은 내일 퇴근 후에 작업하도록 하겠습니다. (피드백 후 머지 된 내용대로 진행할 예정) 

# 중점적으로 봐줬으면 하는 부분
- 무한 스크롤로 개선되겠지만 우선 메인에 있던 로직 살짝 수정해서 적용했습니다. (offset, limit)