### PR TITLE
[BM-296] 상세페이지 남은시간 실시간 반영

### DIFF
--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -9,7 +9,6 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 
 import { priceFormat, remainedTimeFormat } from 'utils';
 
@@ -29,13 +28,8 @@ const ProductBid = ({
   expireAt,
 }: ProductBidProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const [remainedTime, setRemainedTime] = useState('0초');
   const router = useRouter();
   const toast = useToast();
-
-  useEffect(() => {
-    setRemainedTime(remainedTimeFormat(expireAt));
-  }, [remainedTime]);
 
   const handleBidButtonClick = () => {
     if (authUserId === -1) {
@@ -94,7 +88,7 @@ const ProductBid = ({
             padding="3px 10px"
             borderRadius="20px"
           >
-            {remainedTime}
+            {remainedTimeFormat(expireAt)}
           </Text>
         </Flex>
         <Button

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -9,8 +9,10 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
 
-import { priceFormat, remainedTimeFormat } from 'utils';
+import useIntervalValue from 'hooks/useIntervalValue';
+import { priceFormat, remainedTimeFormat, remainedTimer } from 'utils';
 
 import ProductBidProgress from './ProductBidDrawer';
 
@@ -28,6 +30,10 @@ const ProductBid = ({
   expireAt,
 }: ProductBidProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const remainedTime = useIntervalValue(
+    () => (new Date(expireAt).getTime() - new Date().getTime()) / 100,
+    1000
+  );
   const router = useRouter();
   const toast = useToast();
 
@@ -88,7 +94,7 @@ const ProductBid = ({
             padding="3px 10px"
             borderRadius="20px"
           >
-            {remainedTimeFormat(expireAt)}
+            {remainedTime}
           </Text>
         </Flex>
         <Button

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -9,12 +9,12 @@ import {
   useToast,
 } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
 
-import useIntervalValue from 'hooks/useIntervalValue';
-import { priceFormat, remainedTimeFormat, remainedTimer } from 'utils';
-
-import ProductBidProgress from './ProductBidDrawer';
+import {
+  ProductBidProgress,
+  ProductBidRemainedTime,
+} from 'components/ProductDetail';
+import { priceFormat } from 'utils';
 
 interface ProductBidProps {
   writerId: number;
@@ -30,10 +30,6 @@ const ProductBid = ({
   expireAt,
 }: ProductBidProps) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
-  const remainedTime = useIntervalValue(
-    () => (new Date(expireAt).getTime() - new Date().getTime()) / 100,
-    1000
-  );
   const router = useRouter();
   const toast = useToast();
 
@@ -88,14 +84,7 @@ const ProductBid = ({
             <Image src="/svg/time.svg" alt="remained-time" />
             <Text>남은 시간</Text>
           </Flex>
-          <Text
-            fontSize="sm"
-            bg="#EFEFEF"
-            padding="3px 10px"
-            borderRadius="20px"
-          >
-            {remainedTime}
-          </Text>
+          <ProductBidRemainedTime expireAt={expireAt} />
         </Flex>
         <Button
           backgroundColor="brand.primary-900"

--- a/components/ProductDetail/ProductBidDrawer.tsx
+++ b/components/ProductDetail/ProductBidDrawer.tsx
@@ -117,7 +117,7 @@ const ProductBidDrawer = ({
                 >
                   <FormErrorMessage>
                     {errors.biddingPrice as string}
-                  </FormErrorMessage>{' '}
+                  </FormErrorMessage>
                   <Text fontSize="sm" color="#007C14" marginTop="8px">
                     {priceFormat(biddingPrice)}원
                   </Text>

--- a/components/ProductDetail/ProductBidRemainedTime.tsx
+++ b/components/ProductDetail/ProductBidRemainedTime.tsx
@@ -49,7 +49,6 @@ const ProductBidRemainedTime = ({ expireAt }: ProductBidRemainedTimeProps) => {
   );
 
   useEffect(() => {
-    console.log(remainedSecondTime);
     if (remainedSecondTime < 0) {
       setRemainedTime('이미 경매가 종료된 상품입니다.');
       return;

--- a/components/ProductDetail/ProductBidRemainedTime.tsx
+++ b/components/ProductDetail/ProductBidRemainedTime.tsx
@@ -1,51 +1,56 @@
 import { Text } from '@chakra-ui/react';
 import { useEffect, useState } from 'react';
 
-import useIntervalValue from 'hooks/useIntervalValue';
+import useIntervalComparedValue from 'hooks/useIntervalComparedValue';
 
 interface ProductBidRemainedTimeProps {
   expireAt: Date;
 }
 
+const DAY_TO_SECONDS = 1000 * 60 * 60 * 24;
+const HOUR_TO_SECONDS = 1000 * 60 * 60;
+const MINUTE_TO_SECONDS = 1000 * 60;
+const SECONDS = 1000;
+
 const ProductBidRemainedTime = ({ expireAt }: ProductBidRemainedTimeProps) => {
   const [remainedTime, setRemainedTime] = useState('계산중입니다.');
 
-  const remainedDayTime = useIntervalValue(
+  const remainedDayTime = useIntervalComparedValue(
     () =>
       Math.floor(
-        (new Date(expireAt).getTime() - new Date().getTime()) /
-          (1000 * 60 * 60 * 24)
+        (new Date(expireAt).getTime() - new Date().getTime()) / DAY_TO_SECONDS
       ),
-    1000
+    SECONDS
   );
 
-  const remainedHourTime = useIntervalValue(
+  const remainedHourTime = useIntervalComparedValue(
     () =>
       Math.floor(
         ((new Date(expireAt).getTime() - new Date().getTime()) %
-          (1000 * 60 * 60 * 24)) /
-          (1000 * 60 * 60)
+          DAY_TO_SECONDS) /
+          HOUR_TO_SECONDS
       ),
-    1000
+    SECONDS
   );
 
-  const remainedMinuteTime = useIntervalValue(
+  const remainedMinuteTime = useIntervalComparedValue(
     () =>
       Math.floor(
         ((new Date(expireAt).getTime() - new Date().getTime()) %
-          (1000 * 60 * 60)) /
-          (1000 * 60)
+          HOUR_TO_SECONDS) /
+          MINUTE_TO_SECONDS
       ),
-    1000
+    SECONDS
   );
 
-  const remainedSecondTime = useIntervalValue(
+  const remainedSecondTime = useIntervalComparedValue(
     () =>
       Math.floor(
-        ((new Date(expireAt).getTime() - new Date().getTime()) % (1000 * 60)) /
-          1000
+        ((new Date(expireAt).getTime() - new Date().getTime()) %
+          MINUTE_TO_SECONDS) /
+          SECONDS
       ),
-    1000
+    SECONDS
   );
 
   useEffect(() => {

--- a/components/ProductDetail/ProductBidRemainedTime.tsx
+++ b/components/ProductDetail/ProductBidRemainedTime.tsx
@@ -14,21 +14,18 @@ const SECONDS = 1000;
 
 const ProductBidRemainedTime = ({ expireAt }: ProductBidRemainedTimeProps) => {
   const [remainedTime, setRemainedTime] = useState('계산중입니다.');
+  const expireTime = new Date(expireAt).getTime();
+  const currentTime = new Date().getTime();
 
   const remainedDayTime = useIntervalComparedValue(
-    () =>
-      Math.floor(
-        (new Date(expireAt).getTime() - new Date().getTime()) / DAY_TO_SECONDS
-      ),
+    () => Math.floor((expireTime - currentTime) / DAY_TO_SECONDS),
     SECONDS
   );
 
   const remainedHourTime = useIntervalComparedValue(
     () =>
       Math.floor(
-        ((new Date(expireAt).getTime() - new Date().getTime()) %
-          DAY_TO_SECONDS) /
-          HOUR_TO_SECONDS
+        ((expireTime - currentTime) % DAY_TO_SECONDS) / HOUR_TO_SECONDS
       ),
     SECONDS
   );
@@ -36,20 +33,14 @@ const ProductBidRemainedTime = ({ expireAt }: ProductBidRemainedTimeProps) => {
   const remainedMinuteTime = useIntervalComparedValue(
     () =>
       Math.floor(
-        ((new Date(expireAt).getTime() - new Date().getTime()) %
-          HOUR_TO_SECONDS) /
-          MINUTE_TO_SECONDS
+        ((expireTime - currentTime) % HOUR_TO_SECONDS) / MINUTE_TO_SECONDS
       ),
     SECONDS
   );
 
   const remainedSecondTime = useIntervalComparedValue(
     () =>
-      Math.floor(
-        ((new Date(expireAt).getTime() - new Date().getTime()) %
-          MINUTE_TO_SECONDS) /
-          SECONDS
-      ),
+      Math.floor(((expireTime - currentTime) % MINUTE_TO_SECONDS) / SECONDS),
     SECONDS
   );
 

--- a/components/ProductDetail/ProductBidRemainedTime.tsx
+++ b/components/ProductDetail/ProductBidRemainedTime.tsx
@@ -1,0 +1,74 @@
+import { Text } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
+
+import useIntervalValue from 'hooks/useIntervalValue';
+
+interface ProductBidRemainedTimeProps {
+  expireAt: Date;
+}
+
+const ProductBidRemainedTime = ({ expireAt }: ProductBidRemainedTimeProps) => {
+  const [remainedTime, setRemainedTime] = useState('계산중입니다.');
+
+  const remainedDayTime = useIntervalValue(
+    () =>
+      Math.floor(
+        (new Date(expireAt).getTime() - new Date().getTime()) /
+          (1000 * 60 * 60 * 24)
+      ),
+    1000
+  );
+
+  const remainedHourTime = useIntervalValue(
+    () =>
+      Math.floor(
+        ((new Date(expireAt).getTime() - new Date().getTime()) %
+          (1000 * 60 * 60 * 24)) /
+          (1000 * 60 * 60)
+      ),
+    1000
+  );
+
+  const remainedMinuteTime = useIntervalValue(
+    () =>
+      Math.floor(
+        ((new Date(expireAt).getTime() - new Date().getTime()) %
+          (1000 * 60 * 60)) /
+          (1000 * 60)
+      ),
+    1000
+  );
+
+  const remainedSecondTime = useIntervalValue(
+    () =>
+      Math.floor(
+        ((new Date(expireAt).getTime() - new Date().getTime()) % (1000 * 60)) /
+          1000
+      ),
+    1000
+  );
+
+  useEffect(() => {
+    console.log(remainedSecondTime);
+    if (remainedSecondTime < 0) {
+      setRemainedTime('이미 경매가 종료된 상품입니다.');
+      return;
+    }
+
+    setRemainedTime(`${remainedDayTime}일 ${remainedHourTime}시간 ${remainedMinuteTime}분
+    ${remainedSecondTime}초`);
+  }, [
+    remainedDayTime,
+    remainedHourTime,
+    remainedMinuteTime,
+    remainedSecondTime,
+  ]);
+
+  return (
+    <Text fontSize="sm" bg="#EFEFEF" padding="3px 10px" borderRadius="20px">
+      {remainedTime}
+    </Text>
+  );
+};
+
+export default ProductBidRemainedTime;

--- a/components/ProductDetail/ProductInfo.tsx
+++ b/components/ProductDetail/ProductInfo.tsx
@@ -46,7 +46,6 @@ const ProductInfo = ({
           {format(new Date(createdAt), 'M월 d일')}
         </Text>
       </Flex>
-
       <Text marginTop="14px" whiteSpace="pre-wrap" marginBottom="158px">
         {description}
       </Text>

--- a/components/ProductDetail/ProductInfo.tsx
+++ b/components/ProductDetail/ProductInfo.tsx
@@ -1,4 +1,4 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Divider, Flex, Text } from '@chakra-ui/react';
 import { differenceInDays, format } from 'date-fns';
 
 interface ProductInfoProps {
@@ -37,9 +37,16 @@ const ProductInfo = ({
           {title}
         </Text>
       </Flex>
-      <Text fontSize="sm" color="#838383" marginTop="7px">
-        {format(new Date(createdAt), 'M월 d일')}
-      </Text>
+      <Flex marginTop="7px">
+        <Text as="u" fontSize="sm" color="#838383">
+          {category}
+        </Text>
+        <Divider orientation="vertical" margin="0 10px" />
+        <Text fontSize="sm" color="#838383">
+          {format(new Date(createdAt), 'M월 d일')}
+        </Text>
+      </Flex>
+
       <Text marginTop="14px" whiteSpace="pre-wrap" marginBottom="158px">
         {description}
       </Text>

--- a/components/ProductDetail/index.tsx
+++ b/components/ProductDetail/index.tsx
@@ -1,5 +1,6 @@
 export { default as ProductBid } from './ProductBid';
-export { default as ProductBidDrawer } from './ProductBidDrawer';
+export { default as ProductBidProgress } from './ProductBidDrawer';
+export { default as ProductBidRemainedTime } from './ProductBidRemainedTime';
 export { default as ProductImage } from './ProductImage';
 export { default as ProductInfo } from './ProductInfo';
 export { default as ProductSeller } from './ProductSeller';

--- a/components/User/NotificationCard.tsx
+++ b/components/User/NotificationCard.tsx
@@ -27,7 +27,7 @@ const Notification = ({
             <Flex direction="column">
               <Text width="100%" paddingTop="5px">
                 {description}
-              </Text>{' '}
+              </Text>
               <Text color="brand.dark-light">
                 {distanceTimeFormat(createdAt)}
               </Text>

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -19,7 +19,7 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
 
   useEffect(() => {
     setRemainedTime(remainedTimeFormat(expireAt));
-  }, [remainedTime]);
+  }, [remainedTime, expireAt]);
 
   return (
     <Flex

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -14,12 +14,7 @@ interface ProductCardProps {
 
 const ProductCard = ({ productInfo }: ProductCardProps) => {
   const { id, title, thumbnailImage, minimumPrice, expireAt } = productInfo;
-  const [remainedTime, setRemainedTime] = useState('0초');
   const router = useRouter();
-
-  useEffect(() => {
-    setRemainedTime(remainedTimeFormat(expireAt));
-  }, [remainedTime, expireAt]);
 
   return (
     <Flex
@@ -58,7 +53,7 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
             padding="3px 10px"
             borderRadius="20px"
           >
-            {remainedTime}
+            {remainedTimeFormat(expireAt)}
           </Text>
         </Flex>
         <Flex justifyContent="flex-end" alignItems="center">

--- a/hooks/useInterval.ts
+++ b/hooks/useInterval.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react';
+
+const useInterval = (callback: any, delay: number) => {
+  const savedCallback = useRef<any>();
+
+  useEffect(() => {
+    savedCallback.current = callback;
+  }, [callback]);
+
+  useEffect(() => {
+    const tick = () => {
+      savedCallback.current();
+    };
+
+    if (delay !== null) {
+      const id = setInterval(tick, delay);
+      return () => clearInterval(id);
+    }
+  }, [delay]);
+};
+
+export default useInterval;

--- a/hooks/useIntervalComparedValue.ts
+++ b/hooks/useIntervalComparedValue.ts
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import useInterval from './useInterval';
 
-const useIntervalValue = (callback: any, delay: number) => {
+const useIntervalComparedValue = (callback: any, delay: number) => {
   const [result, setResult] = useState(callback());
 
   useInterval(() => {
@@ -13,4 +13,4 @@ const useIntervalValue = (callback: any, delay: number) => {
   return result;
 };
 
-export default useIntervalValue;
+export default useIntervalComparedValue;

--- a/hooks/useIntervalValue.ts
+++ b/hooks/useIntervalValue.ts
@@ -1,0 +1,16 @@
+import { useState } from 'react';
+
+import useInterval from './useInterval';
+
+const useIntervalValue = (callback: any, delay: number) => {
+  const [result, setResult] = useState(callback());
+
+  useInterval(() => {
+    const newResult = callback();
+    if (newResult !== result) setResult(newResult);
+  }, delay);
+
+  return result;
+};
+
+export default useIntervalValue;

--- a/utils/format/remainedTimeFormat.ts
+++ b/utils/format/remainedTimeFormat.ts
@@ -16,7 +16,10 @@ const remainedTimeFormat = (expiredTime: Date) => {
     end: expiredTime,
   });
 
-  return formatDuration(remainedTime, { locale: ko });
+  return formatDuration(remainedTime, {
+    format: ['days', 'hours', 'minutes'],
+    locale: ko,
+  });
 };
 
 export default remainedTimeFormat;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] useInterval 훅과 useIntervalComparedValue훅을 만들어서 진행하였습니다. (불필요한 렌더링을 줄이기 위해 사용하였습니다.)
- [x] 남은 시간이 0초가 되면  '이미 경매가 종료된 상품입니다'로 원래처럼 보이도록 진행하였습니다.
- [x] 이제 남은 시간 remainedTimeFormat이 메인에서만 사용되기 때문에 '일, 시, 분'까지만 나오도록 포맷 수정하였습니다.

# 작업 진행 사항
- 남은 시간
![남은 시간 gif](https://user-images.githubusercontent.com/50071076/183828585-6278ff46-4ea9-49da-ad33-1c965285c58f.gif)

- 메인 페이지 남은 시간
![image](https://user-images.githubusercontent.com/50071076/183830956-b796403b-c7c9-40d8-aec2-e2c4a0b6b570.png)


# 관련 이슈
- typescript를 적용할 때 any로 구현한 부분이 있습니다. 
- 다음주 프로젝트 마감까지 시간이 얼마 남지 않아 "남은 시간 구현"에 더 이상 매달리고 있을 수 없어 코드가 많이 부족할 수 있습니다. 감안 부탁드립니다!  부족한 부분은 마감 후 리팩토링 때 진행 예정입니다!

# 중점적으로 봐줬으면 하는 부분
- 함수명, 변수명 부탁드립니다!