### PR TITLE
[BM-318] 알림 페이지 무한 스크롤 적용, 검색페이지에서 무조건 홈으로 가도록 분기처리

### DIFF
--- a/components/common/Header/GoBackIcon.tsx
+++ b/components/common/Header/GoBackIcon.tsx
@@ -4,11 +4,20 @@ import { useRouter } from 'next/router';
 const GoBackIcon = () => {
   const router = useRouter();
 
+  const switchRouter = () => {
+    const pathName = router.pathname;
+    if (pathName === '/products') {
+      router.push('/');
+    } else {
+      router.back();
+    }
+  };
+
   return (
     <ChevronLeftIcon
       _hover={{ cursor: 'pointer' }}
       boxSize="8"
-      onClick={() => router.back()}
+      onClick={() => switchRouter()}
     />
   );
 };


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 알림 페이지 무한 스크롤 적용
   - [x] 알림이 없는 경우 알림 없다고 안내 메시지 표시
- [x] 검색 페이지에서는 홈 페이지로 `뒤로가기`하도록 분기처리
   - 검색를 여러번, 필터를 여러번 하고 홈으로 가려면 뒤로가기를 많이 해야하는 불편함을 개선

# 작업 진행 사항
- 무한스크롤은 메인페이지, 검색 페이지와 동일합니다! (따라서 영상 생략)

# 관련 이슈
- TODO에 적어놓았듯이 다른 무한쿼리 Hook과 중복되는 코드가 있어 리팩토링으로 개선할 예정입니다.

# 중점적으로 봐줬으면 하는 부분
- 변수명, 함수명, 클린 코드 관점에서 확인부탁드립니다.