### PR TITLE
[BM-328] 헤더 타이틀 공통 컴포넌트로 분리

### DIFF
--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -33,7 +33,7 @@ const MainHeader = () => {
               w="24px"
               h="24px"
               _hover={{ cursor: 'pointer' }}
-              onClick={() => router.push(`/user/${userId}/chattings`)}
+              onClick={() => router.push(`/user/${userId}/chat`)}
             />
             <BellIcon
               w="32px"

--- a/components/ProfileEdit/ProfileEditHeader.tsx
+++ b/components/ProfileEdit/ProfileEditHeader.tsx
@@ -1,22 +1,9 @@
-import { Text } from '@chakra-ui/react';
-
-import { Header, GoBackIcon } from 'components/common';
+import { Header, GoBackIcon, HeaderTitle } from 'components/common';
 
 const ProfileEditHeader = () => (
   <Header
     leftContent={<GoBackIcon />}
-    middleContent={
-      <Text
-        fontFamily="Roboto"
-        fontSize="20px"
-        fontWeight="bold"
-        lineHeight="23px"
-        fontStyle="normal"
-        color="barnd.dark"
-      >
-        프로필수정
-      </Text>
-    }
+    middleContent={<HeaderTitle title="프로필 수정" />}
   ></Header>
 );
 

--- a/components/common/Header/HeaderTitle.tsx
+++ b/components/common/Header/HeaderTitle.tsx
@@ -1,0 +1,15 @@
+import { Heading } from '@chakra-ui/react';
+
+interface HeaderTitleProps {
+  title: string;
+}
+
+const HeaderTitle = ({ title }: HeaderTitleProps) => {
+  return (
+    <Heading as="h4" size="md">
+      {title}
+    </Heading>
+  );
+};
+
+export default HeaderTitle;

--- a/components/common/index.tsx
+++ b/components/common/index.tsx
@@ -4,6 +4,7 @@ export { default as ProductCardContainer } from './ProductCardContainer';
 export { default as Header } from './Header';
 export { default as GoBackIcon } from './Header/GoBackIcon';
 export { default as SideBar } from './Header/SideBar';
+export { default as HeaderTitle } from './Header/HeaderTitle';
 
 export { default as SearchInput } from './SearchInput';
 

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,7 +1,7 @@
-import { Flex, Image, Text } from '@chakra-ui/react';
+import { Flex, Image } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
-import { Header, GoBackIcon, SEO } from 'components/common';
+import { Header, GoBackIcon, SEO, HeaderTitle } from 'components/common';
 import { GoogleLoginButton, Phrases } from 'components/Login';
 
 const Login: NextPage = () => {
@@ -10,7 +10,7 @@ const Login: NextPage = () => {
       <SEO title="로그인" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={<Text>비드마켓</Text>}
+        middleContent={<HeaderTitle title="비드마켓" />}
       />
       <Flex direction="column" alignItems="center" marginTop="50px">
         <Phrases />

--- a/pages/product/index.tsx
+++ b/pages/product/index.tsx
@@ -9,7 +9,7 @@ import type { NextPage } from 'next';
 import { useState } from 'react';
 
 import { productAPI } from 'apis';
-import { Header, GoBackIcon } from 'components/common';
+import { Header, GoBackIcon, HeaderTitle } from 'components/common';
 import { SEO } from 'components/common';
 import {
   AddProductTitle,
@@ -104,11 +104,7 @@ const Product: NextPage = () => {
       <form style={{ width: '100%', height: '100%' }} onSubmit={handleSubmit}>
         <Header
           leftContent={<GoBackIcon />}
-          middleContent={
-            <Text fontWeight="bold" fontSize="20px">
-              상품등록
-            </Text>
-          }
+          middleContent={<HeaderTitle title="상품 등록" />}
           rightContent={
             <SubmitButton isLoading={isLoading} loadingText={'전송 중'} />
           }

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -10,6 +10,7 @@ import {
   SearchInput,
   SEO,
   ProductCardContainer,
+  HeaderTitle,
 } from 'components/common';
 import { BidFilterCheckBox, FilterButton } from 'components/Products';
 import { useGetProductsByKeyword } from 'hooks/queries';
@@ -95,7 +96,10 @@ const Products = ({
   return (
     <>
       <SEO title="검색" />
-      <Header leftContent={<GoBackIcon />} middleContent={<Text>검색</Text>} />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<HeaderTitle title="검색" />}
+      />
       <Flex direction="column" w="100%" h="100%">
         <form onSubmit={(event) => handleFormSubmit(event)}>
           <SearchInput keyword={keyword} onChange={setKeyword} />

--- a/pages/user/[userId]/chat/index.tsx
+++ b/pages/user/[userId]/chat/index.tsx
@@ -1,4 +1,4 @@
-import { Center, Divider, Spinner, Text } from '@chakra-ui/react';
+import { Center, Divider, Spinner } from '@chakra-ui/react';
 import type {
   GetServerSideProps,
   InferGetServerSidePropsType,
@@ -8,7 +8,7 @@ import { useRouter } from 'next/router';
 import { Fragment, useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
-import { GoBackIcon, Header } from 'components/common';
+import { GoBackIcon, Header, HeaderTitle } from 'components/common';
 import { NoChatting, ChattingCard } from 'components/User';
 import useLoginUser from 'hooks/useLoginUser';
 import { ChatRoomData, ChatRoomResponseType } from 'types/chatRooms';
@@ -107,7 +107,10 @@ const Chats: NextPage = ({
 
   return (
     <>
-      <Header leftContent={<GoBackIcon />} middleContent={<Text>채팅</Text>} />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<HeaderTitle title="채팅" />}
+      />
       {chatRooms.length ? (
         chatRooms.map(
           ({

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -8,7 +8,13 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import userAPI from 'apis/api/user';
-import { GoBackIcon, Header, SEO, SideBar } from 'components/common';
+import {
+  GoBackIcon,
+  Header,
+  HeaderTitle,
+  SEO,
+  SideBar,
+} from 'components/common';
 import {
   ProductMenuList,
   UserProfileEditButton,
@@ -63,18 +69,7 @@ const UserId: NextPage = ({
       <SEO title="회원 정보 페이지" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={
-          <Text
-            fontFamily="Roboto"
-            fontSize="20px"
-            fontWeight="bold"
-            lineHeight="23px"
-            fontStyle="normal"
-            color="barnd.dark"
-          >
-            {isMyPage ? '마이페이지' : ''}
-          </Text>
-        }
+        middleContent={<HeaderTitle title={isMyPage ? '마이페이지' : ''} />}
       />
       <Flex width="100%" flexDirection="column" gap="29px">
         <UserProfileInformation

--- a/pages/user/[userId]/notifications/index.tsx
+++ b/pages/user/[userId]/notifications/index.tsx
@@ -1,12 +1,12 @@
 import { DownloadIcon } from '@chakra-ui/icons';
-import { Button, Center, Spinner, Text } from '@chakra-ui/react';
+import { Button, Center, Spinner } from '@chakra-ui/react';
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { userAPI } from 'apis';
 import { getItem } from 'apis/utils/storage';
-import { GoBackIcon, Header } from 'components/common';
+import { GoBackIcon, Header, HeaderTitle } from 'components/common';
 import { NoNotifications, NotificationCard } from 'components/User';
 import { useGetNotifications } from 'hooks/queries';
 import useLoginUser from 'hooks/useLoginUser';
@@ -69,7 +69,10 @@ const Notifications = ({
 
   return (
     <>
-      <Header leftContent={<GoBackIcon />} middleContent={<Text>알림</Text>} />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<HeaderTitle title="알림" />}
+      />
       {notificationPages?.pages.map(({ data }) => {
         return data.map(
           ({ id, productId, type, content, thumbnailImage, createdAt }) => {

--- a/pages/user/[userId]/notifications/index.tsx
+++ b/pages/user/[userId]/notifications/index.tsx
@@ -1,5 +1,4 @@
-import { DownloadIcon } from '@chakra-ui/icons';
-import { Button, Center, Spinner } from '@chakra-ui/react';
+import { Center, Spinner } from '@chakra-ui/react';
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
@@ -77,7 +76,10 @@ const Notifications = ({
 
   return (
     <>
-      <Header leftContent={<GoBackIcon />} middleContent={<Text>알림</Text>} />
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<HeaderTitle title="알림" />}
+      />
       {/* @TODO 컴포넌트로 분리해보기 */}
       {notificationPages?.pages.map(({ data }, pageIndex) => {
         return data.map(

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -1,10 +1,16 @@
 import { DownloadIcon } from '@chakra-ui/icons';
-import { Button, Center, Divider, Spinner, Text } from '@chakra-ui/react';
+import { Button, Center, Divider, Spinner } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 import { Fragment, useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
-import { GoBackIcon, Header, ProductCard, SEO } from 'components/common';
+import {
+  GoBackIcon,
+  Header,
+  HeaderTitle,
+  ProductCard,
+  SEO,
+} from 'components/common';
 import { NoProducts } from 'components/User';
 import { ProductsResponseType } from 'types/product';
 
@@ -50,17 +56,7 @@ const Bid: NextPage = () => {
       <SEO title="사용자 이름" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={
-          <Text
-            fontFamily="Roboto"
-            fontSize="20px"
-            fontWeight="700"
-            lineHeight="23px"
-            color="barnd.dark"
-          >
-            입찰한 상품
-          </Text>
-        }
+        middleContent={<HeaderTitle title="입찰한 상품" />}
       />
       {biddingProducts.length === 0 ? (
         <Center flexDirection="column" height="100%">

--- a/pages/user/[userId]/products/like/index.tsx
+++ b/pages/user/[userId]/products/like/index.tsx
@@ -1,7 +1,7 @@
 import { Center, Text } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
-import { GoBackIcon, Header, SEO } from 'components/common';
+import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
 import { NoProducts } from 'components/User';
 
 // @ TODO 데이터 가져와서 연결 작업
@@ -14,7 +14,7 @@ const Like: NextPage = () => {
       <SEO title="사용자 이름" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={<Text>찜한 상품</Text>}
+        middleContent={<HeaderTitle title="찜한 상품" />}
       />
       {DUMMY.length === 0 ? (
         <Center flexDirection="column" height="100%">

--- a/pages/user/[userId]/products/sell/index.tsx
+++ b/pages/user/[userId]/products/sell/index.tsx
@@ -1,7 +1,7 @@
 import { Center, Text } from '@chakra-ui/react';
 import type { NextPage } from 'next';
 
-import { GoBackIcon, Header, SEO } from 'components/common';
+import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
 import { NoProducts } from 'components/User';
 
 // @ TODO 데이터 가져와서 연결 작업
@@ -16,7 +16,7 @@ const Sell: NextPage = () => {
       <SEO title="사용자 이름" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={<Text>판매한 상품</Text>}
+        middleContent={<HeaderTitle title="판매한 상품" />}
       />
       {DUMMY.length === 0 ? (
         <Center flexDirection="column" height="100%">


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 헤더 타이틀 UI 디자인 공통 컴포넌트로 분리
- [x] 메인 헤더에서 채팅 페이지롱 이동하는 라우트 경로 수정

# 작업 진행 사항
- 아래와 같이 통일되도록 모두 변경하였습니다.
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/184300139-cab23a7f-d9ee-4d4d-8d19-ad03467f7c19.png">


# 관련 이슈
- 머지 시 충돌로 알림 페이지 헤더 컴포넌트 다시 적용

# 중점적으로 봐줬으면 하는 부분
없습니다.