### PR TITLE
[BM-326] 경매 종료 후 1분 대기 로직 구현

### DIFF
--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -60,6 +60,8 @@ const ProductBid = ({
     biddingSucceed: false,
     chatRoomId: 0,
   });
+  const [isCalculatingBiddingResult, setIsCalculatingBiddingResult] =
+    useState(false);
 
   useEffect(() => {
     if (isExpiredBidding) {
@@ -67,12 +69,20 @@ const ProductBid = ({
       return;
     }
 
-    setTimeout(() => {
-      router.reload();
-    }, remainedBiddingTime + MINUTE_TO_SECONDS);
-
+    calculatingBiddingResult();
     getBiddingPrice();
   }, [isExpiredBidding]);
+
+  const calculatingBiddingResult = () => {
+    setTimeout(() => {
+      setIsCalculatingBiddingResult(true);
+    }, remainedBiddingTime);
+
+    setTimeout(() => {
+      setIsCalculatingBiddingResult(false);
+      router.reload();
+    }, remainedBiddingTime + MINUTE_TO_SECONDS);
+  };
 
   const getBiddingResultByRole = async () => {
     try {
@@ -216,9 +226,13 @@ const ProductBid = ({
           _active={{
             borderColor: '#brand.primary-900',
           }}
-          disabled={isBidButtonDisabled()}
+          disabled={isCalculatingBiddingResult ? true : isBidButtonDisabled()}
         >
-          <Text color="white">{getButtonNameByStatus()}</Text>
+          <Text color="white">
+            {isCalculatingBiddingResult
+              ? '잠시 후에 낙찰 결과가 공개됩니다.'
+              : getButtonNameByStatus()}
+          </Text>
         </Button>
         <ProductBidProgress
           minimumPrice={minimumPrice}

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -28,7 +28,7 @@ const BIDDING_TEXT = '입찰하기';
 const CHATTING_TEXT = '채팅하기';
 const PRODUCT_RECREATE_TEXT = '상품 재등록하기';
 const BIDDING_END_PRODUCT_TEXT = '입찰 종료된 상품입니다.';
-
+const MINUTE_TO_SECONDS = 60000;
 interface ProductBidProps {
   writerId: number;
   authUserId: number;
@@ -46,8 +46,10 @@ const ProductBid = ({
   const router = useRouter();
   const toast = useToast();
   const { productId } = router.query;
-  const isExpiredBidding =
-    Math.floor(new Date(expireAt).getTime() - new Date().getTime()) < 0;
+  const remainedBiddingTime = Math.floor(
+    new Date(expireAt).getTime() - new Date().getTime()
+  );
+  const isExpiredBidding = Math.floor(remainedBiddingTime) < 0;
   const isSeller = writerId === authUserId;
   const [seller, setSeller] = useState({
     biddingSucceed: false,
@@ -64,6 +66,11 @@ const ProductBid = ({
       getBiddingResultByRole();
       return;
     }
+
+    setTimeout(() => {
+      router.reload();
+    }, remainedBiddingTime + MINUTE_TO_SECONDS);
+
     getBiddingPrice();
   }, [isExpiredBidding]);
 

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -29,6 +29,7 @@ const CHATTING_TEXT = '채팅하기';
 const PRODUCT_RECREATE_TEXT = '상품 재등록하기';
 const BIDDING_END_PRODUCT_TEXT = '입찰 종료된 상품입니다.';
 const MINUTE_TO_SECONDS = 60000;
+
 interface ProductBidProps {
   writerId: number;
   authUserId: number;

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -69,20 +69,9 @@ const ProductBid = ({
       return;
     }
 
-    calculatingBiddingResult();
     getBiddingPrice();
+    calculateBiddingResult();
   }, [isExpiredBidding]);
-
-  const calculatingBiddingResult = () => {
-    setTimeout(() => {
-      setIsCalculatingBiddingResult(true);
-    }, remainedBiddingTime);
-
-    setTimeout(() => {
-      setIsCalculatingBiddingResult(false);
-      router.reload();
-    }, remainedBiddingTime + MINUTE_TO_SECONDS);
-  };
 
   const getBiddingResultByRole = async () => {
     try {
@@ -123,6 +112,17 @@ const ProductBid = ({
     } catch (error) {
       console.log(error);
     }
+  };
+
+  const calculateBiddingResult = () => {
+    setTimeout(() => {
+      setIsCalculatingBiddingResult(true);
+    }, remainedBiddingTime);
+
+    setTimeout(() => {
+      setIsCalculatingBiddingResult(false);
+      router.reload();
+    }, remainedBiddingTime + MINUTE_TO_SECONDS);
   };
 
   const isShowBiddingEndText = () => {


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 경매 종료 후 1분 대기 로직 구현

# 작업 진행 사항
- 경매 종료 후 1분동안 버튼 disabled와 '잠시 후 낙찰 결과가 공개됩니다' 문구 출력
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/184325345-2aaf5287-be2e-49ad-af52-5f2c3f79f18a.png">

- 1분이 지난 후에 화면 reload와 낙찰 결과에 따른 버튼 활성화
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/184325518-e320ca39-fd22-4284-b1dd-741765d85656.png">

# 관련 이슈
TODO
- 낙찰 결과에 따른 버튼 라우트 구현(채팅하기 혹은 상품 재등록버튼)

# 중점적으로 봐줬으면 하는 부분
- 클린코드를 위해 함수명, 변수명 리뷰 부탁드립니다.