### PR TITLE
[BM-325] 낙찰 했을 경우 채팅 버튼 연결과 UI 적용

### DIFF
--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -135,6 +135,7 @@ const ProductBid = ({
       if (!isSeller && !bidder.biddingSucceed) {
         return true;
       }
+      return false;
     }
 
     if (isSeller) {

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -160,14 +160,29 @@ const ProductBid = ({
   };
 
   const handleBidButtonClick = () => {
+    if (isSeller && !seller.biddingSucceed) {
+      router.push(`/product`);
+      return;
+    }
+
+    if (seller.biddingSucceed) {
+      router.push(`/user/${authUserId}/chat/${seller.chatRoomId}`);
+      return;
+    }
+
+    if (bidder.biddingSucceed) {
+      router.push(`/user/${authUserId}/chat/${bidder.chatRoomId}`);
+      return;
+    }
+
     if (authUserId === -1) {
       toast(
         setToastInfo('top', '입찰은 로그인 후 이용 가능합니다.', 'warning')
       );
-
       router.push('/login');
       return;
     }
+
     onOpen();
   };
 

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -52,7 +52,9 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
             padding="3px 10px"
             borderRadius="20px"
           >
-            {remainedTimeFormat(expireAt)}
+            {remainedTimeFormat(expireAt) === ''
+              ? '0분'
+              : remainedTimeFormat(expireAt)}
           </Text>
         </Flex>
         <Flex justifyContent="flex-end" alignItems="center">


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 낙찰 했을 경우 채팅 버튼 연결과 UI 적용
- [x] 메인페이지에서 1분 미만일 때 텍스트가 안보이던 버그 수정

# 작업 진행 사항
- 입찰자가 낙찰에 성공하였을 때
![image](https://user-images.githubusercontent.com/50071076/184395116-8f10151c-b184-4341-b98e-f4d48ebd4844.png)

- 판매자가 낙찰에 성공하였을 때
![image](https://user-images.githubusercontent.com/50071076/184404862-bd11b5a2-9069-4a99-a31b-35b74f38b1fd.png)

# 관련 이슈
- 낙찰 관련 로직 전부 적용되었습니다. 실행해보시고 버그 확인 부탁드립니다!
- 상품 재등록하기 버튼 클릭시 상품 등록 부분으로 이동하도록 구현하였습니다.
  - 이 부분에서 재등록 버튼을 눌렀을 때 바로 상품이 다시 등록되는 것이 좋을 것 같은데 어떻게 생각하시나요!? 댓글 꼭 부탁드리겠습니다! 

# 중점적으로 봐줬으면 하는 부분
- 클린코드를위해 변수명, 함수명, 컴포넌트명 확인 부탁드려요!