### PR TITLE
[BM-333] 상품 상세 페이지 페이지 넘기는 기능 구현

### DIFF
--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -1,4 +1,6 @@
-import { Image } from '@chakra-ui/react';
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import { Box, IconButton, Image, Progress } from '@chakra-ui/react';
+import { useEffect, useState } from 'react';
 
 import { Image as ImageType } from 'types/product';
 
@@ -7,14 +9,65 @@ interface ProductImageProps {
 }
 
 const ProductImage = ({ images }: ProductImageProps) => {
+  const [showImage, setShowImage] = useState(1);
+
   return (
-    <Image
-      width="100%"
-      height="317px"
-      objectFit="cover"
-      alt="product-image"
-      src={images.length ? images[0].url : '/svg/basket.svg'}
-    />
+    <>
+      {/* @TODO 슬라이드 개선할 예정 + 모바일에서는 화살표 안보이게 */}
+      {/* @TODO 화살표 버튼 레퍼런스 더 찾아보기 */}
+      <IconButton
+        position="absolute"
+        top="150px"
+        left="15px"
+        variant="ghost"
+        isRound
+        _active={{ bg: 'brand.primary-100' }}
+        _hover={{ bg: 'none' }}
+        disabled={showImage === 1}
+        aria-label="Prev Product Image"
+        icon={<ChevronLeftIcon w={5} h={5} />}
+        onClick={() => setShowImage(showImage - 1)}
+      />
+      {images.map(({ order, url }) => {
+        return (
+          <Image
+            key={order}
+            display={order === showImage ? 'visible' : 'none'}
+            width="100%"
+            height="317px"
+            objectFit="contain"
+            alt="product-image"
+            src={url ?? '/svg/basket.svg'}
+          />
+        );
+      })}
+      <Box
+        sx={{
+          '#progress > div': {
+            bg: 'brand.primary-900',
+          },
+        }}
+      >
+        <Progress
+          id="progress"
+          value={(showImage / images.length) * 100}
+          size="xs"
+        />
+      </Box>
+      <IconButton
+        position="absolute"
+        top="150px"
+        right="15px"
+        variant="ghost"
+        isRound
+        _active={{ bg: 'brand.primary-100' }}
+        _hover={{ bg: 'none' }}
+        disabled={showImage === images.length}
+        aria-label="Next Product Image"
+        icon={<ChevronRightIcon w={5} h={5} />}
+        onClick={() => setShowImage(showImage + 1)}
+      />
+    </>
   );
 };
 

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -41,7 +41,7 @@ const ProductDetail = ({
   return (
     <>
       <SEO title={title} description={description} />
-      <Box position="absolute">
+      <Box position="absolute" maxWidth="768px" width="100%">
         <ProductImage images={images} />
       </Box>
       <Box position="absolute" left="15px" top="20px" cursor="pointer">


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 상품 상세 페이지에서 페이지 넘기는 기능 구현
- [x] 몇번째 상품인지 인지하도록 progressBar 추가 구현

# 작업 진행 사항
https://user-images.githubusercontent.com/75886763/184476033-baff88ff-b5bf-4d30-9d5d-e4a73a3cdac2.mov


# 관련 이슈
- 일단은 제 임의대로 progressBar를 추가하였는데 리팩토링때 다른 UI로 안건이 나온다면 개선할 생각입니다.

# 중점적으로 봐줬으면 하는 부분
- 없습니다.