### PR TITLE
[BM-341] 회원 정보 페이지 3차 UI 반영 및 로그아웃, 회원탈퇴 페이지 구현

### DIFF
--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -1,3 +1,4 @@
+import { ChevronRightIcon } from '@chakra-ui/icons';
 import { Flex, Divider, Text, Image } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 
@@ -20,36 +21,30 @@ const ProductMenuItem = ({
     <>
       <Flex
         width="100%"
-        flexDirection="column"
         alignItems="center"
         gap="13px"
         onClick={() => router.push(routingUrl)}
       >
-        <Image
-          width="33.92px"
-          height="38px"
-          src={iconUrl}
-          alt={`${title} 아이콘`}
-        />
-        <Text
-          flexGrow="1"
-          color="brand.dark"
-          fontFamily="Roboto"
-          fontStyle="normal"
-          fontWeight="400"
-          fontSize="14"
-          lineHeight="128.19%"
-        >
-          {title}
-        </Text>
+        <Flex justifyContent="space-between" alignItems="center" gap="10px">
+          <Image
+            width="33.92px"
+            height="38px"
+            src={iconUrl}
+            alt={`${title} 아이콘`}
+          />
+          <Text
+            color="brand.dark"
+            fontFamily="Roboto"
+            fontStyle="normal"
+            fontSize="16px"
+            lineHeight="128.19%"
+          >
+            {title}
+          </Text>
+        </Flex>
+        <ChevronRightIcon />
       </Flex>
-      {!isLastItem && (
-        <Divider
-          orientation="vertical"
-          border="3px solid #EFEFEF"
-          height="20px"
-        />
-      )}
+      {!isLastItem && <Divider />}
     </>
   );
 };

--- a/components/User/ProductMenuList.tsx
+++ b/components/User/ProductMenuList.tsx
@@ -27,13 +27,7 @@ const ProductMenuList = ({ userId }: ProductMenuListProps) => {
   ];
 
   return (
-    <Flex
-      width="100%"
-      justifyContent="center"
-      alignItems="center"
-      gap="12px"
-      marginTop="21px"
-    >
+    <Flex direction="column" width="100%" gap="12px" marginTop="21px">
       {productMenu.map((currentMenu, index) => (
         <Fragment key={index}>
           <ProductMenuItem

--- a/components/User/UserProfileEditButton.tsx
+++ b/components/User/UserProfileEditButton.tsx
@@ -1,14 +1,26 @@
-import { EditIcon } from '@chakra-ui/icons';
+import { EditIcon, WarningTwoIcon } from '@chakra-ui/icons';
 import { Button, Text } from '@chakra-ui/react';
 
 interface UserProfileEditButtonProps {
+  text: 'edit' | 'report';
   onClick: () => void;
 }
 
-const UserProfileEditButton = ({ onClick }: UserProfileEditButtonProps) => {
+const UserProfileEditButton = ({
+  text,
+  onClick,
+}: UserProfileEditButtonProps) => {
+  const isMyPage = text === 'edit';
+  const buttonText = isMyPage ? '프로필 수정하기' : '신고하기';
+  const buttonIcon = isMyPage ? (
+    <EditIcon color="brand.primary-900" />
+  ) : (
+    <WarningTwoIcon color="brand.primary-900" />
+  );
+
   return (
     <Button
-      leftIcon={<EditIcon color="brand.primary-900" />}
+      leftIcon={buttonIcon}
       width="100%"
       border="1.5px dashed"
       borderColor="brand.primary-900"
@@ -23,7 +35,7 @@ const UserProfileEditButton = ({ onClick }: UserProfileEditButtonProps) => {
         fontWeight="400"
         fontSize="15"
       >
-        프로필 수정하기
+        {buttonText}
       </Text>
     </Button>
   );

--- a/components/User/UserProfileEditOrReportButton.tsx
+++ b/components/User/UserProfileEditOrReportButton.tsx
@@ -1,15 +1,15 @@
 import { EditIcon, WarningTwoIcon } from '@chakra-ui/icons';
 import { Button, Text } from '@chakra-ui/react';
 
-interface UserProfileEditReportButtonProps {
+interface UserProfileEditOrReportButtonProps {
   text: 'edit' | 'report';
   onClick: () => void;
 }
 
-const UserProfileEditReportButton = ({
+const UserProfileEditOrReportButton = ({
   text,
   onClick,
-}: UserProfileEditReportButtonProps) => {
+}: UserProfileEditOrReportButtonProps) => {
   const isMyPage = text === 'edit';
   const buttonText = isMyPage ? '프로필 수정하기' : '신고하기';
   const buttonIcon = isMyPage ? (
@@ -41,4 +41,4 @@ const UserProfileEditReportButton = ({
   );
 };
 
-export default UserProfileEditReportButton;
+export default UserProfileEditOrReportButton;

--- a/components/User/UserProfileEditReportButton.tsx
+++ b/components/User/UserProfileEditReportButton.tsx
@@ -1,15 +1,15 @@
 import { EditIcon, WarningTwoIcon } from '@chakra-ui/icons';
 import { Button, Text } from '@chakra-ui/react';
 
-interface UserProfileEditButtonProps {
+interface UserProfileEditReportButtonProps {
   text: 'edit' | 'report';
   onClick: () => void;
 }
 
-const UserProfileEditButton = ({
+const UserProfileEditReportButton = ({
   text,
   onClick,
-}: UserProfileEditButtonProps) => {
+}: UserProfileEditReportButtonProps) => {
   const isMyPage = text === 'edit';
   const buttonText = isMyPage ? '프로필 수정하기' : '신고하기';
   const buttonIcon = isMyPage ? (
@@ -41,4 +41,4 @@ const UserProfileEditButton = ({
   );
 };
 
-export default UserProfileEditButton;
+export default UserProfileEditReportButton;

--- a/components/User/UserSetting.tsx
+++ b/components/User/UserSetting.tsx
@@ -1,35 +1,38 @@
-import { Flex, Img, Text } from '@chakra-ui/react';
+import { ChevronRightIcon, SettingsIcon } from '@chakra-ui/icons';
+import { Flex, Text } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 
-import { removeItem } from 'apis/utils/storage';
+interface UserSettingProps {
+  userId: number;
+}
 
-const UserSetting = () => {
+const UserSetting = ({ userId }: UserSettingProps) => {
   const router = useRouter();
 
   return (
     <Flex flexDirection="column" width="100%" marginTop="21px" gap="19px">
-      <Text
-        textAlign="left"
-        color="brand.dark"
-        fontFamily="Roboto"
-        fontStyle="normal"
-        fontWeight="700"
-        fontSize="16px"
-        lineHeight="128.19%"
-      >
-        계정 설정
-      </Text>
       <Flex
         alignItems="center"
+        justifyContent="space-between"
         gap="16px"
         cursor="pointer"
         onClick={() => {
-          removeItem('token');
-          router.push('/');
+          router.push(`/user/${userId}/setting`);
         }}
       >
-        <Img src="/svg/logout.svg" />
-        <Text>로그아웃</Text>
+        <Flex alignItems="center" gap="10px">
+          <SettingsIcon />
+          <Text
+            textAlign="left"
+            color="brand.dark"
+            fontFamily="Roboto"
+            fontStyle="normal"
+            fontSize="16px"
+          >
+            계정 설정
+          </Text>
+        </Flex>
+        <ChevronRightIcon />
       </Flex>
     </Flex>
   );

--- a/components/User/index.tsx
+++ b/components/User/index.tsx
@@ -1,6 +1,6 @@
 export { default as UserSetting } from './UserSetting';
 export { default as UserProfileInformation } from './UserProfileInformation';
-export { default as UserProfileEditButton } from './UserProfileEditButton';
+export { default as UserProfileEditReportButton } from './UserProfileEditReportButton';
 export { default as ProductMenuList } from './ProductMenuList';
 export { default as ProductMenuItem } from './ProductMenuItem';
 export { default as NoProducts } from './NoProducts';

--- a/components/User/index.tsx
+++ b/components/User/index.tsx
@@ -1,6 +1,6 @@
 export { default as UserSetting } from './UserSetting';
 export { default as UserProfileInformation } from './UserProfileInformation';
-export { default as UserProfileEditReportButton } from './UserProfileEditReportButton';
+export { default as UserProfileEditOrReportButton } from './UserProfileEditOrReportButton';
 export { default as ProductMenuList } from './ProductMenuList';
 export { default as ProductMenuItem } from './ProductMenuItem';
 export { default as NoProducts } from './NoProducts';

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -1,20 +1,14 @@
-import { Center, Divider, Flex, Spinner, Text } from '@chakra-ui/react';
+import { Center, Divider, Flex, Spinner } from '@chakra-ui/react';
 import type {
   GetServerSideProps,
   InferGetServerSidePropsType,
   NextPage,
 } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import userAPI from 'apis/api/user';
-import {
-  GoBackIcon,
-  Header,
-  HeaderTitle,
-  SEO,
-  SideBar,
-} from 'components/common';
+import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
 import {
   ProductMenuList,
   UserProfileEditButton,
@@ -76,8 +70,15 @@ const UserId: NextPage = ({
           profileImageUrl={profileImage}
           nickname={username}
         />
-        {isMyPage && (
+        {isMyPage ? (
           <UserProfileEditButton
+            text={'edit'}
+            onClick={() => router.push(`./${userId}/edit`)}
+          />
+        ) : (
+          <UserProfileEditButton
+            text={'report'}
+            // @NOTE 신고하기 페이지로 이동으로 코드 변경 매우 필요
             onClick={() => router.push(`./${userId}/edit`)}
           />
         )}
@@ -92,7 +93,7 @@ const UserId: NextPage = ({
             boxShadow="inset 0px 1px 3px rgba(0, 0, 0, 0.03)"
             marginTop="25px"
           />
-          <UserSetting />
+          <UserSetting userId={authUserId} />
         </>
       ) : undefined}
     </>

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -11,7 +11,7 @@ import userAPI from 'apis/api/user';
 import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
 import {
   ProductMenuList,
-  UserProfileEditReportButton,
+  UserProfileEditOrReportButton,
   UserProfileInformation,
   UserSetting,
 } from 'components/User';
@@ -73,12 +73,12 @@ const UserId: NextPage = ({
           nickname={username}
         />
         {isMyPage ? (
-          <UserProfileEditReportButton
+          <UserProfileEditOrReportButton
             text={'edit'}
             onClick={() => router.push(`./${userId}/edit`)}
           />
         ) : (
-          <UserProfileEditReportButton
+          <UserProfileEditOrReportButton
             text={'report'}
             // @NOTE 신고하기 페이지로 이동으로 코드 변경 매우 필요
             onClick={() => router.push(`./${userId}/edit`)}

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -63,7 +63,9 @@ const UserId: NextPage = ({
       <SEO title="회원 정보 페이지" />
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={<HeaderTitle title={isMyPage ? '마이페이지' : ''} />}
+        middleContent={
+          <HeaderTitle title={isMyPage ? '마이페이지' : '회원 정보'} />
+        }
       />
       <Flex width="100%" flexDirection="column" gap="29px">
         <UserProfileInformation

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -11,7 +11,7 @@ import userAPI from 'apis/api/user';
 import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
 import {
   ProductMenuList,
-  UserProfileEditButton,
+  UserProfileEditReportButton,
   UserProfileInformation,
   UserSetting,
 } from 'components/User';
@@ -71,12 +71,12 @@ const UserId: NextPage = ({
           nickname={username}
         />
         {isMyPage ? (
-          <UserProfileEditButton
+          <UserProfileEditReportButton
             text={'edit'}
             onClick={() => router.push(`./${userId}/edit`)}
           />
         ) : (
-          <UserProfileEditButton
+          <UserProfileEditReportButton
             text={'report'}
             // @NOTE 신고하기 페이지로 이동으로 코드 변경 매우 필요
             onClick={() => router.push(`./${userId}/edit`)}

--- a/pages/user/[userId]/setting/index.tsx
+++ b/pages/user/[userId]/setting/index.tsx
@@ -1,0 +1,95 @@
+import { Center, Divider, Flex, Spinner, Text } from '@chakra-ui/react';
+import {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+import { userAPI } from 'apis';
+import { removeItem } from 'apis/utils/storage';
+import { GoBackIcon, Header, SEO } from 'components/common';
+import useLoginUser from 'hooks/useLoginUser';
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { userId } = context.query;
+  let user = {};
+
+  try {
+    const { data } = await userAPI.getUser(parseInt(userId as string, 10));
+
+    user = data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+    },
+  };
+};
+
+const Setting: NextPage = ({
+  user: { id },
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const router = useRouter();
+  const { userId } = router.query;
+  const { id: authUserId } = useLoginUser();
+  const isMyPage = id === authUserId;
+  // @TODO 회원탈퇴 구현 예정
+
+  useEffect(() => {
+    if (!id) {
+      router.replace('/404');
+    }
+  }, [id, router]);
+
+  if (!id) {
+    return (
+      <Center height="100%">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
+
+  return (
+    <>
+      <SEO title="회원 설정 페이지" />
+      <Header leftContent={<GoBackIcon />} />
+      <Flex
+        direction="column"
+        justifyContent="space-between"
+        alignItems="center"
+        width="100%"
+        h="85%"
+      >
+        <Flex width="100%" direction="column">
+          <Text
+            fontSize="16px"
+            margin="16px 0"
+            cursor="pointer"
+            onClick={() => {
+              removeItem('token');
+              router.push('/');
+            }}
+          >
+            로그아웃
+          </Text>
+          <Divider />
+        </Flex>
+        <Text
+          color="#A6A6A6"
+          fontSize="14px"
+          textDecoration="underline"
+          cursor="pointer"
+        >
+          회원탈퇴
+        </Text>
+      </Flex>
+    </>
+  );
+};
+
+export default Setting;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 회원 정보 페이지 3차 UI 반영
   - [x] 본인 회원 정보 페이지 : 프로필 수정 하기
   - [x] 다른 회원 정보 페이지 : 신고하기
- [x] 로그아웃, 회원탈퇴 페이지 구현
   - [x] 로그아웃 구현완료 (기존 로직 재사용) 

# 작업 진행 사항
- 본인 회원 정보 페이지
<img width="320" alt="image" src="https://user-images.githubusercontent.com/75886763/184480405-604818d9-e434-4941-93b2-49f430cd12d9.png">

- 로그아웃, 회원탈퇴 페이지
<img width="315" alt="image" src="https://user-images.githubusercontent.com/75886763/184480413-77fd48c2-46eb-4386-b0cf-364b6129a7a7.png">

- 타인 회원 정보 페이지
<img width="319" alt="image" src="https://user-images.githubusercontent.com/75886763/184480462-29a27b27-a5fc-4493-a477-df006387b1c2.png">


# 관련 이슈
- 회원 신고하기 API 연동이 예정되어있습니다. (TODO 작성 완료)

# 중점적으로 봐줬으면 하는 부분
- 변수명, 함수명, 불필요한 코드, 컴포넌트명 등 확인 부탁드립니다.
- 기존의 `UserProfileEditButton`을 `UserProfileEditReportButton`으로 변경하였습니다. 더 적절한 변수명이 생각나시면 코멘트 부탁드립니다.
   - 이유 : 해당 컴포넌트에서 프로필 수정 기능 또는 신고하기 기능을 수행하기 때문입니다.