### PR TITLE
[BM-343] 검색 페이지 Drawer 선택된 옵션 체크 및 상품 상세 페이지 상품 사진 갯수에 따라 분기처리

### DIFF
--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -11,9 +11,26 @@ interface ProductImageProps {
 const ProductImage = ({ images }: ProductImageProps) => {
   const [showImage, setShowImage] = useState(1);
 
+  if (images.length === 1) {
+    const { order, url } = images[0];
+    return (
+      <Image
+        key={order}
+        display={order === showImage ? 'visible' : 'none'}
+        width="100%"
+        height="317px"
+        objectFit="contain"
+        alt="product-image"
+        src={url ?? '/svg/basket.svg'}
+      />
+    );
+  }
+
   return (
     <>
       {/* @TODO 슬라이드 개선할 예정 + 모바일에서는 화살표 안보이게 */}
+      {/* @TODO 모바일에서 좌우화살표 클릭해도 커진 상태 유지되는 현상 개선 필요 (위의 TODO와 함께 개선 예정) */}
+      {/* 만약 최종 제출 영상을 위해 제거하고 싶은 경우 제거 가능 */}
       {/* @TODO 화살표 버튼 레퍼런스 더 찾아보기 */}
       <IconButton
         position="absolute"
@@ -21,30 +38,44 @@ const ProductImage = ({ images }: ProductImageProps) => {
         left="15px"
         variant="ghost"
         isRound
+        zIndex={2}
         _active={{ bg: 'brand.primary-100' }}
         _hover={{ bg: 'none' }}
         disabled={showImage === 1}
         aria-label="Prev Product Image"
-        icon={<ChevronLeftIcon w={5} h={5} />}
+        icon={
+          <ChevronLeftIcon
+            w={5}
+            h={5}
+            _hover={{ transform: 'scale(2)' }}
+            transition="all ease 0.2s 0s"
+          />
+        }
         onClick={() => setShowImage(showImage - 1)}
       />
-      {images.map(({ order, url }) => {
-        return (
-          <Image
-            key={order}
-            display={order === showImage ? 'visible' : 'none'}
-            width="100%"
-            height="317px"
-            objectFit="contain"
-            alt="product-image"
-            src={url ?? '/svg/basket.svg'}
-          />
-        );
-      })}
+      <Box position="relative" w="100%" h="317px">
+        {images.map(({ order, url }) => {
+          return (
+            <Image
+              key={order}
+              position="absolute"
+              zIndex={1}
+              opacity={order === showImage ? '1' : '0'}
+              width="100%"
+              height="317px"
+              objectFit="contain"
+              alt="product-image"
+              src={url ?? '/svg/basket.svg'}
+              transition="all ease 0.3s 0s"
+            />
+          );
+        })}
+      </Box>
       <Box
         sx={{
           '#progress > div': {
             bg: 'brand.primary-900',
+            transition: 'all ease 0.3s 0s',
           },
         }}
       >
@@ -56,6 +87,7 @@ const ProductImage = ({ images }: ProductImageProps) => {
       </Box>
       <IconButton
         position="absolute"
+        zIndex={2}
         top="150px"
         right="15px"
         variant="ghost"
@@ -64,7 +96,14 @@ const ProductImage = ({ images }: ProductImageProps) => {
         _hover={{ bg: 'none' }}
         disabled={showImage === images.length}
         aria-label="Next Product Image"
-        icon={<ChevronRightIcon w={5} h={5} />}
+        icon={
+          <ChevronRightIcon
+            w={5}
+            h={5}
+            _hover={{ transform: 'scale(2)' }}
+            transition="all ease 0.2s 0s"
+          />
+        }
         onClick={() => setShowImage(showImage + 1)}
       />
     </>

--- a/components/Products/FilterButton.tsx
+++ b/components/Products/FilterButton.tsx
@@ -1,4 +1,4 @@
-import { ChevronDownIcon } from '@chakra-ui/icons';
+import { CheckIcon, ChevronDownIcon } from '@chakra-ui/icons';
 import {
   Button,
   Divider,
@@ -82,9 +82,16 @@ const FilterButton = ({
               return (
                 <Fragment key={index}>
                   <Text
-                    _hover={{ cursor: 'pointer' }}
+                    _hover={{
+                      cursor: 'pointer',
+                      bgGradient:
+                        'linear(to-b, #FFFFFF, brand.primary-500, #FFFFFF)',
+                    }}
                     onClick={() => handleFilterButtonClick(optionName)}
                   >
+                    {selectedFilterOption === optionName && (
+                      <CheckIcon color="brand.primary-900" marginRight="10px" />
+                    )}
                     {optionName}
                   </Text>
                   {index !== OPTIONS.length - 1 ? (

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -44,7 +44,13 @@ const ProductDetail = ({
       <Box position="absolute" maxWidth="768px" width="100%">
         <ProductImage images={images} />
       </Box>
-      <Box position="absolute" left="15px" top="20px" cursor="pointer">
+      <Box
+        position="absolute"
+        zIndex={3}
+        left="15px"
+        top="20px"
+        cursor="pointer"
+      >
         {/* //TODO 색상 props 적용 */}
         <GoBackIcon />
       </Box>


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 검색 페이지 Drawer에서 카테고리 옵션, 정렬 옵션 선택한 것이 Drawer 안에서도 표시되도록 구현 
- [x] 상품 상세 페이지에서 상품 사진이 1개인 경우 progressBar, 화살표 표시 제거
- [x] 상품 상세 페이지 상품 사진 전환시 progressBar, 사진 자연스럽게 변화하도록 구현
- [x] 상품 상세 페이지 화살표 hover시 2배 커지도록 구현

# 작업 진행 사항
https://user-images.githubusercontent.com/75886763/184495587-2ad5de68-0aa9-41fc-9e2b-ec9adb25a652.mov


# 관련 이슈
- 모바일 화면에서는 터치 1번했을 때 hover상태를 유지하게되므로 향후 개선 예정
- 만약 최종 발표 영상을 위해 제거되길 원하신다면 제거하셔도 됩니다!

# 중점적으로 봐줬으면 하는 부분
- 없습니다.