### PR TITLE
[BM-342] 회원탈퇴 API 연동

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -26,7 +26,8 @@ const userAPI = {
       `/chatRooms?offset=${offset}&limit=${limit}`
     ),
   updateUser: (username: string, profileImage: string) =>
-    authInstance.patch('users', { username, profileImage }),
+    authInstance.patch('/users', { username, profileImage }),
+  deleteUser: () => authInstance.delete('/users'),
 };
 
 export default userAPI;

--- a/pages/user/[userId]/setting/index.tsx
+++ b/pages/user/[userId]/setting/index.tsx
@@ -8,9 +8,8 @@ import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 
 import { userAPI } from 'apis';
-import { removeItem } from 'apis/utils/storage';
+import { getItem, removeItem } from 'apis/utils/storage';
 import { GoBackIcon, Header, SEO } from 'components/common';
-import useLoginUser from 'hooks/useLoginUser';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { userId } = context.query;
@@ -35,13 +34,9 @@ const Setting: NextPage = ({
   user: { id },
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
-  const { userId } = router.query;
-  const { id: authUserId } = useLoginUser();
-  const isMyPage = id === authUserId;
-  // @TODO 회원탈퇴 구현 예정
 
   useEffect(() => {
-    if (!id) {
+    if (!id || !getItem('token')) {
       router.replace('/404');
     }
   }, [id, router]);
@@ -84,6 +79,11 @@ const Setting: NextPage = ({
           fontSize="14px"
           textDecoration="underline"
           cursor="pointer"
+          onClick={async () => {
+            await userAPI.deleteUser();
+            removeItem('token');
+            router.push('/');
+          }}
         >
           회원탈퇴
         </Text>

--- a/pages/user/[userId]/setting/index.tsx
+++ b/pages/user/[userId]/setting/index.tsx
@@ -1,4 +1,11 @@
-import { Center, Divider, Flex, Spinner, Text } from '@chakra-ui/react';
+import {
+  Center,
+  Divider,
+  Flex,
+  Spinner,
+  Text,
+  useToast,
+} from '@chakra-ui/react';
 import {
   GetServerSideProps,
   InferGetServerSidePropsType,
@@ -10,6 +17,7 @@ import { useEffect } from 'react';
 import { userAPI } from 'apis';
 import { getItem, removeItem } from 'apis/utils/storage';
 import { GoBackIcon, Header, SEO } from 'components/common';
+import { setToastInfo } from 'utils';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { userId } = context.query;
@@ -34,6 +42,7 @@ const Setting: NextPage = ({
   user: { id },
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
+  const toast = useToast();
 
   useEffect(() => {
     if (!id || !getItem('token')) {
@@ -48,6 +57,28 @@ const Setting: NextPage = ({
       </Center>
     );
   }
+
+  const handleLogoutClick = () => {
+    removeItem('token');
+    router.push('/');
+  };
+
+  const handleQuitClick = async () => {
+    try {
+      await userAPI.deleteUser();
+      removeItem('token');
+      router.push('/');
+    } catch (error) {
+      console.log(error);
+      toast(
+        setToastInfo(
+          'top',
+          '회원탈퇴 중 문제가 생겼습니다.\n다시 시도바랍니다.',
+          'warning'
+        )
+      );
+    }
+  };
 
   return (
     <>
@@ -65,10 +96,7 @@ const Setting: NextPage = ({
             fontSize="16px"
             margin="16px 0"
             cursor="pointer"
-            onClick={() => {
-              removeItem('token');
-              router.push('/');
-            }}
+            onClick={handleLogoutClick}
           >
             로그아웃
           </Text>
@@ -79,11 +107,7 @@ const Setting: NextPage = ({
           fontSize="14px"
           textDecoration="underline"
           cursor="pointer"
-          onClick={async () => {
-            await userAPI.deleteUser();
-            removeItem('token');
-            router.push('/');
-          }}
+          onClick={handleQuitClick}
         >
           회원탈퇴
         </Text>


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 회원 탈퇴 API 연동
   - [x] `회원탈퇴 api` 요청 -> `토큰 삭제` -> `메인페이지`로 이동

# 작업 진행 사항
https://user-images.githubusercontent.com/75886763/184496945-f4f1c17a-a770-4ba8-b941-8eee3263a7ce.mov


# 관련 이슈
- 없습니다.

# 중점적으로 봐줬으면 하는 부분
- 없습니다.