### PR TITLE
[BM-276] 회원 정보 (판매한 상품, 입찰한 상품) 목록 조회 무한 스크롤 적용

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -7,7 +7,6 @@ import { User } from 'types/user';
 interface GetSellProductsType {
   userId: number;
   offset: number;
-  limit?: number;
   sort?: string;
 }
 
@@ -23,7 +22,6 @@ const userAPI = {
   getSellProducts: ({
     userId,
     offset,
-    limit,
     sort = 'END_DATE_ASC',
   }: GetSellProductsType) =>
     baseInstance.get<ProductsResponseType>(

--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -4,6 +4,13 @@ import { ChatRoomResponseType } from 'types/chatRooms';
 import { ProductsResponseType } from 'types/product';
 import { User } from 'types/user';
 
+interface GetSellProductsType {
+  userId: number;
+  offset: number;
+  limit?: number;
+  sort?: string;
+}
+
 interface GetBiddingProductsType {
   offset: number;
   limit: number;
@@ -13,6 +20,15 @@ interface GetBiddingProductsType {
 const userAPI = {
   getAuthUser: () => authInstance.get<User>('users/auth'),
   getUser: (id: number) => baseInstance.get<User>(`/users/${id}`),
+  getSellProducts: ({
+    userId,
+    offset,
+    limit,
+    sort = 'END_DATE_ASC',
+  }: GetSellProductsType) =>
+    baseInstance.get<ProductsResponseType>(
+      `/users/${userId}/products?offset=${offset}&limit=10&sort=${sort}`
+    ),
   getBiddingProducts: ({
     offset,
     limit,

--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -12,7 +12,6 @@ interface GetSellProductsType {
 
 interface GetBiddingProductsType {
   offset: number;
-  limit: number;
   sort?: string;
 }
 
@@ -29,11 +28,10 @@ const userAPI = {
     ),
   getBiddingProducts: ({
     offset,
-    limit,
     sort = 'END_DATE_ASC',
   }: GetBiddingProductsType) =>
     authInstance.get<ProductsResponseType>(
-      `/users/biddings?offset=${offset}&limit=${limit}&sort=${sort}`
+      `/users/biddings?offset=${offset}&limit=10&sort=${sort}`
     ),
   getChatRooms: (offset: number, limit: number) =>
     authInstance.get<ChatRoomResponseType>(

--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -21,6 +21,7 @@ const ProductMenuItem = ({
     <>
       <Flex
         width="100%"
+        justifyContent="space-between"
         alignItems="center"
         gap="13px"
         onClick={() => router.push(routingUrl)}

--- a/components/User/ProductMenuList.tsx
+++ b/components/User/ProductMenuList.tsx
@@ -5,9 +5,10 @@ import { ProductMenuItem } from '.';
 
 interface ProductMenuListProps {
   userId: string;
+  isMyPage: boolean;
 }
 
-const ProductMenuList = ({ userId }: ProductMenuListProps) => {
+const ProductMenuList = ({ userId, isMyPage }: ProductMenuListProps) => {
   const productMenu = [
     {
       iconUrl: '/svg/sellProductMenuIcon.svg',
@@ -25,6 +26,14 @@ const ProductMenuList = ({ userId }: ProductMenuListProps) => {
       routingUrl: `./${userId}/products/like`,
     },
   ];
+
+  if (!isMyPage) {
+    return (
+      <Flex direction="column" width="100%" gap="12px" marginTop="21px">
+        <ProductMenuItem {...productMenu[0]} isLastItem={true} />
+      </Flex>
+    );
+  }
 
   return (
     <Flex direction="column" width="100%" gap="12px" marginTop="21px">

--- a/hooks/queries/index.ts
+++ b/hooks/queries/index.ts
@@ -1,5 +1,11 @@
 import useGetNotifications from './notification/useGetNotifications';
 import useGetProducts from './product/useGetProducts';
 import useGetProductsByKeyword from './product/useGetProductsByKeyword';
+import useGetUserSellProducts from './user/useGetUserSellProducts';
 
-export { useGetProducts, useGetProductsByKeyword, useGetNotifications };
+export {
+  useGetProducts,
+  useGetProductsByKeyword,
+  useGetNotifications,
+  useGetUserSellProducts,
+};

--- a/hooks/queries/index.ts
+++ b/hooks/queries/index.ts
@@ -1,11 +1,13 @@
 import useGetNotifications from './notification/useGetNotifications';
 import useGetProducts from './product/useGetProducts';
 import useGetProductsByKeyword from './product/useGetProductsByKeyword';
+import useGetUserBidProducts from './user/useGetUserBidProducts';
 import useGetUserSellProducts from './user/useGetUserSellProducts';
 
 export {
   useGetProducts,
   useGetProductsByKeyword,
   useGetNotifications,
+  useGetUserBidProducts,
   useGetUserSellProducts,
 };

--- a/hooks/queries/user/useGetUserBidProducts.ts
+++ b/hooks/queries/user/useGetUserBidProducts.ts
@@ -1,0 +1,29 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { userAPI } from 'apis';
+
+const LIMIT = 10;
+
+const getUserBidProductsAPI = async ({ pageParam = 0 }) => {
+  const { data } = await userAPI.getBiddingProducts({ offset: pageParam });
+
+  return {
+    data,
+    currentPage: pageParam,
+    isLast: data.length ? false : true,
+  };
+};
+
+const useGetUserBidProducts = () => {
+  return useInfiniteQuery(['products'], getUserBidProductsAPI, {
+    getNextPageParam: (lastPage) => {
+      if (lastPage.isLast) {
+        return undefined;
+      }
+
+      return lastPage.currentPage + LIMIT;
+    },
+  });
+};
+
+export default useGetUserBidProducts;

--- a/hooks/queries/user/useGetUserSellProducts.ts
+++ b/hooks/queries/user/useGetUserSellProducts.ts
@@ -1,0 +1,39 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { userAPI } from 'apis';
+
+const LIMIT = 10;
+
+const getUserSellProductsAPI = async ({
+  pageParam = 0,
+  userId,
+}: {
+  pageParam: number;
+  userId: number;
+}) => {
+  const { data } = await userAPI.getSellProducts({ userId, offset: pageParam });
+
+  return {
+    data,
+    currentPage: pageParam,
+    isLast: data.length ? false : true,
+  };
+};
+
+const useGetUserSellProducts = ({ userId }: { userId: number }) => {
+  return useInfiniteQuery(
+    ['products'],
+    ({ pageParam = 0 }) => getUserSellProductsAPI({ pageParam, userId }),
+    {
+      getNextPageParam: (lastPage) => {
+        if (lastPage.isLast) {
+          return undefined;
+        }
+
+        return lastPage.currentPage + LIMIT;
+      },
+    }
+  );
+};
+
+export default useGetUserSellProducts;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -41,8 +41,9 @@ const Home: NextPage = () => {
           return data.map((product, productIndex) => {
             const lastPageIndex = productPages.pages.length - 1;
             const lastProductIndex = data.length - 1;
-            return lastPageIndex === pageIndex &&
-              lastProductIndex === productIndex ? (
+            const isLastProduct =
+              lastPageIndex === pageIndex && lastProductIndex === productIndex;
+            return isLastProduct ? (
               <div ref={ref} key={product.id}>
                 <ProductCardContainer product={product} />
               </div>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -128,8 +128,9 @@ const Products = ({
           return data.map((product, productIndex) => {
             const lastPageIndex = productPages.pages.length - 1;
             const lastProductIndex = data.length - 1;
-            return lastPageIndex === pageIndex &&
-              lastProductIndex === productIndex ? (
+            const isLastProduct =
+              lastPageIndex === pageIndex && lastProductIndex === productIndex;
+            return isLastProduct ? (
               <div ref={ref} key={product.id}>
                 <ProductCardContainer product={product} />
               </div>

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -35,6 +35,7 @@ const Products = ({
   const [isProgressed, setIsProgressed] = useState<boolean>(
     Boolean(JSON.parse(progressed))
   );
+
   // @TODO 쿼리스트링이 누락된 경우 메인페이지로 이동하는 예외처리
   const {
     data: productPages,

--- a/pages/user/[userId]/index.tsx
+++ b/pages/user/[userId]/index.tsx
@@ -97,7 +97,7 @@ const UserId: NextPage = ({
           />
         )}
       </Flex>
-      <ProductMenuList userId={userId as string} />
+      <ProductMenuList userId={userId as string} isMyPage={isMyPage} />
       {isMyPage ? (
         <>
           <Divider

--- a/pages/user/[userId]/notifications/index.tsx
+++ b/pages/user/[userId]/notifications/index.tsx
@@ -97,8 +97,10 @@ const Notifications = ({
           ) => {
             const lastPageIndex = notificationPages.pages.length - 1;
             const lastNotificationIndex = data.length - 1;
-            return lastPageIndex === pageIndex &&
-              lastNotificationIndex === notificationIndex ? (
+            const isLastNotification =
+              lastPageIndex === pageIndex &&
+              lastNotificationIndex === notificationIndex;
+            return isLastNotification ? (
               <div ref={ref} key={id}>
                 <NotificationCard
                   id={id}

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -1,14 +1,18 @@
-import { DownloadIcon } from '@chakra-ui/icons';
-import { Button, Center, Divider, Spinner } from '@chakra-ui/react';
-import type { NextPage } from 'next';
-import { Fragment, useEffect } from 'react';
+import { Center, Spinner } from '@chakra-ui/react';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
 import { useInView } from 'react-intersection-observer';
 
+import { userAPI } from 'apis';
 import {
   GoBackIcon,
   Header,
   HeaderTitle,
-  ProductCard,
   ProductCardContainer,
   SEO,
 } from 'components/common';
@@ -16,8 +20,29 @@ import { NoProducts } from 'components/User';
 import { useGetUserBidProducts } from 'hooks/queries';
 import useLoginUser from 'hooks/useLoginUser';
 
-const Bid: NextPage = () => {
-  const { id: authUserId, username } = useLoginUser();
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  const { userId } = query;
+  let user = {};
+
+  try {
+    user = (await userAPI.getUser(parseInt(userId as string, 10))).data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+    },
+  };
+};
+
+const Bid: NextPage = ({
+  user: { id, username },
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const router = useRouter();
+  const userId = parseInt(id, 10);
+  const { id: authUserId } = useLoginUser();
   const {
     data: productPages,
     fetchNextPage,
@@ -26,8 +51,12 @@ const Bid: NextPage = () => {
   const [ref, isView] = useInView();
 
   useEffect(() => {
-    console.log(authUserId);
     if (authUserId === -1) {
+      return;
+    }
+
+    if (userId !== authUserId) {
+      router.push('/');
       return;
     }
   }, [authUserId]);
@@ -38,7 +67,12 @@ const Bid: NextPage = () => {
     }
   }, [isView, productPages]);
 
-  if (!authUserId) {
+  // @TODO 토큰이 없는 경우 계속 Spinner 렌더링 현상 개선 필요
+  // useLoginUser 내부에 토큰여부에 의해서든 API에 의해서든 업데이트 되었다는 신호가 필요
+  // @TODO 페이지에 진입 후 판단하는 문제 존재
+  // 따라서 찰나의 순간 목록이 렌더링된다 -> 불필요한 작업으로 성능 다운
+  // cf) 토큰은 있지만 다른 회원인 경우 메인페이지로 이동
+  if (authUserId === -1) {
     return (
       <Center height="100%">
         <Spinner size="xl" />

--- a/pages/user/[userId]/products/bid/index.tsx
+++ b/pages/user/[userId]/products/bid/index.tsx
@@ -91,8 +91,9 @@ const Bid: NextPage = ({
         return data.map((product, productIndex) => {
           const lastPageIndex = productPages.pages.length - 1;
           const lastProductIndex = data.length - 1;
-          return lastPageIndex === pageIndex &&
-            lastProductIndex === productIndex ? (
+          const isLastProduct =
+            lastPageIndex === pageIndex && lastProductIndex === productIndex;
+          return isLastProduct ? (
             <div ref={ref} key={product.id}>
               <ProductCardContainer product={product} />
             </div>

--- a/pages/user/[userId]/products/sell/index.tsx
+++ b/pages/user/[userId]/products/sell/index.tsx
@@ -64,7 +64,6 @@ const Sell: NextPage = ({
 
   return (
     <>
-      {/* @ TODO 실제 사용자 닉네임으로 교체 예정 */}
       <SEO title={username + '판매한 상품'} />
       <Header
         leftContent={<GoBackIcon />}

--- a/pages/user/[userId]/products/sell/index.tsx
+++ b/pages/user/[userId]/products/sell/index.tsx
@@ -73,8 +73,9 @@ const Sell: NextPage = ({
         return data.map((product, productIndex) => {
           const lastPageIndex = productPages.pages.length - 1;
           const lastProductIndex = data.length - 1;
-          return lastPageIndex === pageIndex &&
-            lastProductIndex === productIndex ? (
+          const isLastProduct =
+            lastPageIndex === pageIndex && lastProductIndex === productIndex;
+          return isLastProduct ? (
             <div ref={ref} key={product.id}>
               <ProductCardContainer product={product} />
             </div>

--- a/pages/user/[userId]/products/sell/index.tsx
+++ b/pages/user/[userId]/products/sell/index.tsx
@@ -64,7 +64,7 @@ const Sell: NextPage = ({
 
   return (
     <>
-      <SEO title={username + '판매한 상품'} />
+      <SEO title={`${username}의 판매한 상품`} />
       <Header
         leftContent={<GoBackIcon />}
         middleContent={<HeaderTitle title="판매한 상품" />}

--- a/pages/user/[userId]/products/sell/index.tsx
+++ b/pages/user/[userId]/products/sell/index.tsx
@@ -1,33 +1,97 @@
-import { Center, Text } from '@chakra-ui/react';
-import type { NextPage } from 'next';
+import { Center } from '@chakra-ui/react';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
 
-import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
+import { userAPI } from 'apis';
+import {
+  GoBackIcon,
+  Header,
+  HeaderTitle,
+  ProductCardContainer,
+  SEO,
+} from 'components/common';
 import { NoProducts } from 'components/User';
+import { useGetUserSellProducts } from 'hooks/queries';
+import useLoginUser from 'hooks/useLoginUser';
 
-// @ TODO 데이터 가져와서 연결 작업
-const DUMMY = [];
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  const { userId } = query;
+  let user = {};
 
-const Sell: NextPage = () => {
-  // @ TODO 유저 정보와 접속자 정보 비교하는 작업 필요
-  const isOwnerUser = false;
+  try {
+    user = (await userAPI.getUser(parseInt(userId as string, 10))).data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+    },
+  };
+};
+
+const Sell: NextPage = ({
+  user: { id, username },
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const userId = parseInt(id, 10);
+  const { id: authUserId } = useLoginUser();
+  const [isMyPage, setIsMyPage] = useState(false);
+
+  const {
+    data: productPages,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetUserSellProducts({ userId });
+  const [ref, isView] = useInView();
+
+  useEffect(() => {
+    if (userId === authUserId) {
+      setIsMyPage(true);
+    }
+  }, [authUserId]);
+
+  useEffect(() => {
+    if (isView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [isView, productPages]);
+
   return (
     <>
       {/* @ TODO 실제 사용자 닉네임으로 교체 예정 */}
-      <SEO title="사용자 이름" />
+      <SEO title={username + '판매한 상품'} />
       <Header
         leftContent={<GoBackIcon />}
         middleContent={<HeaderTitle title="판매한 상품" />}
       />
-      {DUMMY.length === 0 ? (
+      {productPages?.pages.map(({ data }, pageIndex) => {
+        return data.map((product, productIndex) => {
+          const lastPageIndex = productPages.pages.length - 1;
+          const lastProductIndex = data.length - 1;
+          return lastPageIndex === pageIndex &&
+            lastProductIndex === productIndex ? (
+            <div ref={ref} key={product.id}>
+              <ProductCardContainer product={product} />
+            </div>
+          ) : (
+            <ProductCardContainer key={product.id} product={product} />
+          );
+        });
+      })}
+      {productPages?.pages[0].data.length === 0 && (
         <Center flexDirection="column" height="100%">
-          {isOwnerUser ? (
+          {isMyPage ? (
             <NoProducts pageName="userSellProducts" />
           ) : (
             <NoProducts pageName="userSellProductsOther" />
           )}
         </Center>
-      ) : (
-        <Text>list of Product Cards</Text>
       )}
     </>
   );


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 회원 정보 판매한 상품 페이지 무한 스크롤 적용
- [x] 회원 정보 입찰한 상품 페이지 무한 스크롤 적용
   - [x] 다른 회원이 진입하는 경우 메인페이지로 이동

# 작업 진행 사항
- 무한 스크롤 화면은 앞서 보셨던 영상과 동일합니다.

# 관련 이슈
- `useLoginUser` Hook에서 개선 필요 (리팩토링)
   - 토큰이 없는 경우 `userInfo.id` -> `-1`
   - 토큰이 있지만 API로 업데이트 하기 전 `userInfo.id` -> `-1`
   - 따라서 `useInfo.id`가 계속 `-1`일때 토큰이 없어서인지 API가 아직인지 판단하기 어렵습니다.
   - 혹시나 제가 잘못 이해하였다면 슬랙, 커멘트 어떠한 방법으로든 알려주신다면 감사하겠습니다!!

# 중점적으로 봐줬으면 하는 부분
- 앞서 보셨던 무한스크롤 코드와 거의 동일합니다.
   - 무한 쿼리 관련 Hook들간의 중복되는 코드가 많으므로 리팩토링에서 개선될 예정입니다.
- 변수명, 함수명, 불필요하거나 분리해야할 코드가 있는지 작은 부분이라도 커멘트 작성해주시면 감사하겠습니다!