### PR TITLE
[BM-302] STOMP 프로토콜로 채팅 기능 구현

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -1,5 +1,6 @@
 import { authInstance } from 'apis/utils/authInstance';
 import { baseInstance } from 'apis/utils/baseInstance';
+import { ChatMeesageResponseType } from 'types/chatMessages';
 import { ChatRoomResponseType } from 'types/chatRooms';
 import { ProductsResponseType } from 'types/product';
 import { User } from 'types/user';
@@ -8,6 +9,12 @@ interface GetBiddingProductsType {
   offset: number;
   limit: number;
   sort?: string;
+}
+
+interface GetChatRoomMessagesType {
+  chatRoomId: number;
+  offset: number;
+  limit: number;
 }
 
 const userAPI = {
@@ -24,6 +31,14 @@ const userAPI = {
   getChatRooms: (offset: number, limit: number) =>
     authInstance.get<ChatRoomResponseType>(
       `/chatRooms?offset=${offset}&limit=${limit}`
+    ),
+  getChatMessagesByChatRoomId: ({
+    chatRoomId,
+    offset = 0,
+    limit = 10,
+  }: GetChatRoomMessagesType) =>
+    authInstance.get<ChatMeesageResponseType>(
+      `/chatRooms/${chatRoomId}/messages/?offset=${offset}&limit=${limit}`
     ),
   updateUser: (username: string, profileImage: string) =>
     authInstance.patch('/users', { username, profileImage }),

--- a/components/User/ChattingCard.tsx
+++ b/components/User/ChattingCard.tsx
@@ -8,6 +8,7 @@ interface ChattingProps {
   previewChat: string;
   productImage: string;
   createdAt: Date;
+  onClick: () => void;
 }
 
 const ChattingCard = ({
@@ -16,9 +17,10 @@ const ChattingCard = ({
   previewChat,
   productImage,
   createdAt,
+  onClick,
 }: ChattingProps) => {
   return (
-    <Box cursor="pointer" width="100%">
+    <Box cursor="pointer" width="100%" onClick={onClick}>
       <Flex width="100%" padding="15px 0">
         <Image
           src={profileImage}

--- a/hooks/useStomp.ts
+++ b/hooks/useStomp.ts
@@ -47,11 +47,9 @@ const useStomp = ({ chatRoomId, userInfo, setMessages }: UseStompProps) => {
         }
 
         if (message.body) {
-          const { chatUserInfo, content, createdAt } = JSON.parse(message.body);
-
           setMessages((prevMessages) => [
             ...prevMessages,
-            { userInfo: chatUserInfo, content, createdAt },
+            JSON.parse(message.body),
           ]);
         }
       }

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,7 @@ const nextConfig = {
   publicRuntimeConfig: {
     customBaseUrl: `${process.env.NEXT_APP_API_END_POINT}`,
     googleLoginUrl: `${process.env.GOOGLE_LOGIN_URL}`,
+    stompUrl: `${process.env.STOMP_END_POINT}`,
   },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.2.4",
         "@emotion/react": "^11.9.3",
         "@emotion/styled": "^11.9.3",
+        "@stomp/stompjs": "^6.1.2",
         "@tanstack/react-query": "^4.0.10",
         "@tanstack/react-query-devtools": "^4.0.10",
         "aws-sdk": "^2.1185.0",
@@ -21,12 +22,14 @@
         "next": "12.2.3",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "react-intersection-observer": "^9.4.0"
+        "react-intersection-observer": "^9.4.0",
+        "sockjs-client": "^1.6.1"
       },
       "devDependencies": {
         "@types/node": "18.6.0",
         "@types/react": "18.0.15",
         "@types/react-dom": "18.0.6",
+        "@types/sockjs-client": "^1.5.1",
         "@typescript-eslint/eslint-plugin": "^5.30.7",
         "@typescript-eslint/parser": "^5.30.7",
         "eslint": "8.20.0",
@@ -1878,6 +1881,11 @@
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
     },
+    "node_modules/@stomp/stompjs": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-6.1.2.tgz",
+      "integrity": "sha512-FHDTrIFM5Ospi4L3Xhj6v2+NzCVAeNDcBe95YjUWhWiRMrBF6uN3I7AUOlRgT6jU/2WQvvYK8ZaIxFfxFp+uHQ=="
+    },
     "node_modules/@swc/helpers": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
@@ -2015,6 +2023,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "node_modules/@types/sockjs-client": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.1.tgz",
+      "integrity": "sha512-bmZM6A1GPdjF0bcuIUC+50hZEMGkzMsiG9by6X9U+7IZFOiPtz7MJ9h05FSpPVxlj4i+TzzoG3ESo1FJlbLb6A==",
+      "dev": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -3379,6 +3393,14 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3438,6 +3460,17 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
       }
     },
     "node_modules/file-entry-cache": {
@@ -3832,6 +3865,11 @@
       "dependencies": {
         "react-is": "^16.7.0"
       }
+    },
+    "node_modules/http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "node_modules/husky": {
       "version": "8.0.1",
@@ -4848,6 +4886,11 @@
         "node": ">=0.4.x"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5047,6 +5090,11 @@
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
       "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "node_modules/resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -5193,6 +5241,32 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://tidelift.com/funding/github/npm/sockjs-client"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/source-map": {
@@ -5514,6 +5588,15 @@
         "querystring": "0.2.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/url/node_modules/punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -5594,6 +5677,27 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -7018,6 +7122,11 @@
       "integrity": "sha512-LwzQKA4vzIct1zNZzBmRKI9QuNpLgTQMEjsQLf3BXuGYb3QPTP4Yjf6mkdX+X1mYttZ808QpOwAzZjv28kq7DA==",
       "dev": true
     },
+    "@stomp/stompjs": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-6.1.2.tgz",
+      "integrity": "sha512-FHDTrIFM5Ospi4L3Xhj6v2+NzCVAeNDcBe95YjUWhWiRMrBF6uN3I7AUOlRgT6jU/2WQvvYK8ZaIxFfxFp+uHQ=="
+    },
     "@swc/helpers": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.3.tgz",
@@ -7123,6 +7232,12 @@
       "version": "0.16.2",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
       "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew=="
+    },
+    "@types/sockjs-client": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@types/sockjs-client/-/sockjs-client-1.5.1.tgz",
+      "integrity": "sha512-bmZM6A1GPdjF0bcuIUC+50hZEMGkzMsiG9by6X9U+7IZFOiPtz7MJ9h05FSpPVxlj4i+TzzoG3ESo1FJlbLb6A==",
+      "dev": true
     },
     "@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -8099,6 +8214,11 @@
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
       "integrity": "sha512-kEcvvCBByWXGnZy6JUlgAp2gBIUjfCAV6P6TgT1/aaQKcmuAEC4OZTV1I4EWQLz2gxZw76atuVyvHhTxvi0Flw=="
     },
+    "eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8154,6 +8274,14 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
+      }
+    },
+    "faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "requires": {
+        "websocket-driver": ">=0.5.1"
       }
     },
     "file-entry-cache": {
@@ -8443,6 +8571,11 @@
       "requires": {
         "react-is": "^16.7.0"
       }
+    },
+    "http-parser-js": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
+      "integrity": "sha512-SGeBX54F94Wgu5RH3X5jsDtf4eHyRogWX1XGT3b4HuW3tQPM4AaBzoUji/4AAJNXCEOWZ5O0DgZmJw1947gD5Q=="
     },
     "husky": {
       "version": "8.0.1",
@@ -9159,6 +9292,11 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g=="
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9276,6 +9414,11 @@
       "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
       "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="
+    },
     "resolve": {
       "version": "1.22.1",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz",
@@ -9372,6 +9515,28 @@
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
+    },
+    "sockjs-client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.6.1.tgz",
+      "integrity": "sha512-2g0tjOR+fRs0amxENLi/q5TiJTqY+WXFOzb5UwXndlK6TO3U/mirZznpx6w34HVMoc3g7cY24yC/ZMIYnDlfkw==",
+      "requires": {
+        "debug": "^3.2.7",
+        "eventsource": "^2.0.2",
+        "faye-websocket": "^0.11.4",
+        "inherits": "^2.0.4",
+        "url-parse": "^1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
     },
     "source-map": {
       "version": "0.5.7",
@@ -9605,6 +9770,15 @@
         }
       }
     },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "use-callback-ref": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.0.tgz",
@@ -9651,6 +9825,21 @@
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz",
       "integrity": "sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==",
       "dev": true
+    },
+    "websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "requires": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      }
+    },
+    "websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@chakra-ui/react": "^2.2.4",
     "@emotion/react": "^11.9.3",
     "@emotion/styled": "^11.9.3",
+    "@stomp/stompjs": "^6.1.2",
     "@tanstack/react-query": "^4.0.10",
     "@tanstack/react-query-devtools": "^4.0.10",
     "aws-sdk": "^2.1185.0",
@@ -23,12 +24,14 @@
     "next": "12.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-intersection-observer": "^9.4.0"
+    "react-intersection-observer": "^9.4.0",
+    "sockjs-client": "^1.6.1"
   },
   "devDependencies": {
     "@types/node": "18.6.0",
     "@types/react": "18.0.15",
     "@types/react-dom": "18.0.6",
+    "@types/sockjs-client": "^1.5.1",
     "@typescript-eslint/eslint-plugin": "^5.30.7",
     "@typescript-eslint/parser": "^5.30.7",
     "eslint": "8.20.0",

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -10,8 +10,9 @@ import { userAPI } from 'apis';
 import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
 
-export const getServerSideProps: GetServerSideProps = async (context) => {
-  const { userId, chatRoomId } = context.query;
+export const getServerSideProps: GetServerSideProps = async ({
+  query: { userId, chatRoomId },
+}) => {
   let userInfo = {};
 
   try {
@@ -49,13 +50,15 @@ const ChatRoom: NextPage = ({
   }, []);
 
   const getMessages = async () => {
-    const { data } = await userAPI.getChatMessagesByChatRoomId({
-      chatRoomId,
-      offset: 0,
-      limit: 10,
-    });
+    const chatMessages = (
+      await userAPI.getChatMessagesByChatRoomId({
+        chatRoomId,
+        offset: 0,
+        limit: 100,
+      })
+    ).data;
 
-    setMessages([...data.reverse(), ...messages]);
+    setMessages([...chatMessages.reverse(), ...messages]);
   };
 
   const handleKeyup = (e: React.KeyboardEvent) => {

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -1,21 +1,17 @@
 import { Flex, Input, Text } from '@chakra-ui/react';
-import { Client } from '@stomp/stompjs';
 import {
   GetServerSideProps,
   InferGetServerSidePropsType,
   NextPage,
 } from 'next';
-import getConfig from 'next/config';
-import { useCallback, useEffect, useState } from 'react';
-import SockJS from 'sockjs-client';
+import { useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
 import useStomp from 'hooks/useStomp';
-import { ChatMeesageResponseType, ChatMessageData } from 'types/chatMessages';
+import { ChatMeesageResponseType } from 'types/chatMessages';
 
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { userId, chatRoomId } = context.query;
-  console.log(context.query);
   let userInfo = {};
 
   try {

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -1,0 +1,69 @@
+import { Center, Flex, Input, Text } from '@chakra-ui/react';
+import {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import { useEffect, useState } from 'react';
+
+import { userAPI } from 'apis';
+import { ChatMeesageResponseType } from 'types/chatMessages';
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { userId, chatRoomId } = context.query;
+  console.log(context.query);
+  let user = {};
+
+  try {
+    user = (await userAPI.getUser(parseInt(userId as string, 10))).data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+      chatRoomId: parseInt(chatRoomId as string, 10),
+    },
+  };
+};
+
+const ChatRoom: NextPage = ({
+  user: { id },
+  chatRoomId,
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const [messages, setMessages] = useState<ChatMeesageResponseType>([]);
+
+  useEffect(() => {
+    getMessages();
+  }, []);
+
+  const getMessages = async () => {
+    const { data } = await userAPI.getChatMessagesByChatRoomId({
+      chatRoomId,
+      offset: 0,
+      limit: 10,
+    });
+
+    setMessages([...messages, ...data.reverse()]);
+  };
+
+  return (
+    <Flex flexDirection="column" gap={'16px'}>
+      <h1>임시 채팅방이요!</h1>
+      <Flex flexDirection="column" gap={'16px'}>
+        {messages.map(({ userId, content, createdAt }, index) => (
+          <Flex key={index} flexDirection="row" gap={'16px'}>
+            <Text>{userId}</Text>
+            <Text color="red">{content}</Text>
+            <Text>{String(createdAt)}</Text>
+          </Flex>
+        ))}
+      </Flex>
+
+      <Input />
+    </Flex>
+  );
+};
+
+export default ChatRoom;

--- a/pages/user/[userId]/chat/index.tsx
+++ b/pages/user/[userId]/chat/index.tsx
@@ -13,41 +13,6 @@ import { NoChatting, ChattingCard } from 'components/User';
 import useLoginUser from 'hooks/useLoginUser';
 import { ChatRoomData, ChatRoomResponseType } from 'types/chatRooms';
 
-//TODO : 데이터 연결
-const DUMMY = [
-  {
-    chatRoomId: 1,
-    productInfo: {
-      productId: 1,
-      thumbnailImage:
-        'https://user-images.githubusercontent.com/61923768/182772718-258fa024-b207-4203-8e8a-2dc1f3bc21f2.png',
-    },
-    opponentUserInfo: {
-      username: '물안경',
-      profileImage:
-        'https://bid-market-bucket.s3.ap-northeast-2.amazonaws.com/profiles/%E1%84%80%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%A1.png',
-    },
-    lastMessage:
-      '어쩜 이렇게 하늘은 더 파란 건지? 오늘따라 왜 바람은 또 완벽한지? ',
-    lastMessageDate: new Date('2022-07-20T14:36:00'),
-  },
-  {
-    chatRoomId: 2,
-    productInfo: {
-      productId: 1,
-      thumbnailImage:
-        'https://user-images.githubusercontent.com/61923768/182772718-258fa024-b207-4203-8e8a-2dc1f3bc21f2.png',
-    },
-    opponentUserInfo: {
-      username: '물안경',
-      profileImage:
-        'https://bid-market-bucket.s3.ap-northeast-2.amazonaws.com/profiles/%E1%84%80%E1%85%A1%E1%86%B7%E1%84%8C%E1%85%A1.png',
-    },
-    lastMessage: '눈물이 차올라서 고갤 들어 흐르지 못하게 또 살짝 웃어',
-    lastMessageDate: new Date('2022-07-20T14:36:00'),
-  },
-];
-
 export const getServerSideProps: GetServerSideProps = async (context) => {
   const { userId } = context.query;
   let user = {};
@@ -127,6 +92,7 @@ const Chats: NextPage = ({
                 previewChat={lastMessage}
                 productImage={productInfo.thumbnailImage}
                 createdAt={new Date(lastMessageDate)}
+                onClick={() => router.push(`/user/${id}/chat/${chatRoomId}`)}
               />
               <Divider />
             </Fragment>

--- a/pages/user/[userId]/chat/index.tsx
+++ b/pages/user/[userId]/chat/index.tsx
@@ -126,7 +126,7 @@ const Chats: NextPage = ({
                 profileImage={opponentUserInfo.profileImage}
                 previewChat={lastMessage}
                 productImage={productInfo.thumbnailImage}
-                createdAt={lastMessageDate}
+                createdAt={new Date(lastMessageDate)}
               />
               <Divider />
             </Fragment>

--- a/types/chatMessages/index.ts
+++ b/types/chatMessages/index.ts
@@ -1,0 +1,7 @@
+export interface ChatMessageData {
+  userId: number;
+  content: string;
+  createdAt: Date;
+}
+
+export type ChatMeesageResponseType = Array<ChatMessageData>;

--- a/types/chatMessages/index.ts
+++ b/types/chatMessages/index.ts
@@ -1,5 +1,7 @@
+import { User } from 'types/user';
+
 export interface ChatMessageData {
-  userId: number;
+  userInfo: User;
   content: string;
   createdAt: Date;
 }


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] useStomp hook 구현 (웹소켓 연결 및 구독 및 발행)
- [x] 임시 채팅페이지에 채팅 기능 적용

# 작업 진행 사항
https://user-images.githubusercontent.com/16220817/184521418-960557f0-16cf-4435-9df4-8de4a86e41f9.mov

# 관련 이슈
- 해당 PR 머지 후 레이아웃 까지 적용 후에 다시 리팩토링 예정
- 채팅방 하나에서 혼자 채팅 테스트 한거라 실시간으로 여러 채팅방에서 테스트 검증 필요
- .ev.local에 STOMP_END_POINT 설정이 필요함.
- stomp 연결 문제
  - SockJS로 연결을 해야 통신이 가능했던 구조. (백엔드 옵션 설정. 백엔드에서 테스트시 SockJS로 연결해야만 가능했었음)
  - STOMP: 웹소켓 서브 프로토콜.
  - SockJS: 웹소켓이 지원 안되는 브라우저들을 웹소켓 가능 하도록 해주는 라이브러리로 이해. 
  - SockJS는 http, https로 연결을 하기 떄문에 wss를 엔드포인트로 갖고 있는 현재 프로젝트에서는 사용 못하고 필요 없다고 판단.
  - https 주소로 SockJS를 연결 후에 해당 소켓을 stompJS에서 사용하도록 통신 중.
- offset 이슈
  - 채팅 메세지가 역순으로 내려옴(최신 메세지가 0번 index)
  - 무한 스크롤 편하게 하라는 구조. (스크롤 올릴 수록 예전 메세시 offset만 뒤로 요청하면 됨)
  - 근데 실시간으로 채팅을 입력하면 offset이 변하기 때문에 계신이 필요할 것으로 예상.
  - 고민 중 

# 중점적으로 봐줬으면 하는 부분
없습니다.