### PR TITLE
[BM-271] 찜하기, 찜취소하기 API 연동과 메인 페이지 찜 개수 연결

### DIFF
--- a/apis/api/heart/index.tsx
+++ b/apis/api/heart/index.tsx
@@ -1,0 +1,10 @@
+import { authInstance } from 'apis/utils/authInstance';
+
+const heartAPI = {
+  putHeart: (userId: number, productId: number) =>
+    authInstance.put(`/users/${productId}/hearts`, { userId, productId }),
+  deleteHeart: (productId: number) =>
+    authInstance.delete(`/users/${productId}/hearts`),
+};
+
+export default heartAPI;

--- a/apis/index.ts
+++ b/apis/index.ts
@@ -1,7 +1,8 @@
 import bidAPI from './api/bid';
+import heartAPI from './api/heart';
 import notificationAPI from './api/notification';
 import productAPI from './api/product';
 import reportAPI from './api/report';
 import userAPI from './api/user';
 
-export { productAPI, userAPI, bidAPI, notificationAPI, reportAPI };
+export { productAPI, userAPI, bidAPI, notificationAPI, reportAPI, heartAPI };

--- a/components/ProductDetail/ProductHeart.tsx
+++ b/components/ProductDetail/ProductHeart.tsx
@@ -12,6 +12,7 @@ interface ProductHeartProps {
   title: string;
 }
 
+// TODO: 유저가 찜을 했는지에 대한 여부에 따라 찜 하기와 찜 취소하기 분기 처리
 const ProductHeart = ({ productId, userId, title }: ProductHeartProps) => {
   const [isHeartProduct, setIsHeartHeartProduct] = useState(false);
   const toast = useToast();

--- a/components/ProductDetail/ProductHeart.tsx
+++ b/components/ProductDetail/ProductHeart.tsx
@@ -1,0 +1,58 @@
+import { StarIcon } from '@chakra-ui/icons';
+import { useToast } from '@chakra-ui/react';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+
+import { heartAPI } from 'apis';
+import { setToastInfo } from 'utils';
+
+interface ProductHeartProps {
+  productId: number;
+  userId: number;
+  title: string;
+}
+
+const ProductHeart = ({ productId, userId, title }: ProductHeartProps) => {
+  const [isHeartProduct, setIsHeartHeartProduct] = useState(false);
+  const toast = useToast();
+  const router = useRouter();
+
+  const handleHeartClick = async () => {
+    if (userId === -1) {
+      toast(setToastInfo('top', '찜은 로그인 후 이용 가능합니다.', 'warning'));
+      router.push('/login');
+      return;
+    }
+
+    if (!isHeartProduct) {
+      try {
+        await heartAPI.putHeart(productId, userId);
+        setIsHeartHeartProduct(true);
+        toast(setToastInfo('top', `${title} 상품을 찜했습니다!`, 'success'));
+      } catch (error) {
+        console.log(error);
+      }
+    } else {
+      try {
+        await heartAPI.deleteHeart(productId);
+        setIsHeartHeartProduct(false);
+        toast(
+          setToastInfo('top', `${title} 상품의 찜을 취소하였습니다.`, 'success')
+        );
+      } catch (error) {
+        console.log(error);
+      }
+    }
+  };
+
+  return (
+    <StarIcon
+      w="4"
+      color={isHeartProduct ? 'brand.primary-900' : '#BFBFBF'}
+      cursor="pointer"
+      onClick={handleHeartClick}
+    />
+  );
+};
+
+export default ProductHeart;

--- a/components/ProductDetail/index.tsx
+++ b/components/ProductDetail/index.tsx
@@ -4,3 +4,4 @@ export { default as ProductBidRemainedTime } from './ProductBidRemainedTime';
 export { default as ProductImage } from './ProductImage';
 export { default as ProductInfo } from './ProductInfo';
 export { default as ProductSeller } from './ProductSeller';
+export { default as ProductHeart } from './ProductHeart';

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -59,9 +59,11 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
           </Text>
         </Flex>
         <Flex justifyContent="flex-end" alignItems="center">
-          <StarIcon color="#BFBFBF" />
-          <Text fontSize="sm" marginLeft="5px">
-            {heartCount}
+          <StarIcon color="#BFBFBF" w="3" />
+          <Text fontSize="xs" marginLeft="5px" paddingRight="5px">
+            {heartCount
+              ? `${heartCount}명이 이 상품을 찜했어요!`
+              : `아직 아무도 찜하지 않았어요!`}
           </Text>
         </Flex>
       </Flex>

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -12,7 +12,8 @@ interface ProductCardProps {
 }
 
 const ProductCard = ({ productInfo }: ProductCardProps) => {
-  const { id, title, thumbnailImage, minimumPrice, expireAt } = productInfo;
+  const { id, title, thumbnailImage, minimumPrice, expireAt, heartCount } =
+    productInfo;
   const router = useRouter();
 
   return (
@@ -60,7 +61,7 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
         <Flex justifyContent="flex-end" alignItems="center">
           <StarIcon color="#BFBFBF" />
           <Text fontSize="sm" marginLeft="5px">
-            3
+            {heartCount}
           </Text>
         </Flex>
       </Flex>

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -1,4 +1,3 @@
-import { StarIcon } from '@chakra-ui/icons';
 import { Divider, Flex, Box, Image } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
@@ -11,6 +10,7 @@ import {
   ProductImage,
   ProductInfo,
   ProductSeller,
+  ProductHeart,
 } from 'components/ProductDetail';
 import useLoginUser from 'hooks/useLoginUser';
 
@@ -92,7 +92,7 @@ const ProductDetail = ({
             name={writer.username}
             profileImage={writer.profileImage}
           />
-          <StarIcon w="23px" color="brand.primary-900" />
+          <ProductHeart productId={id} userId={authUserId} title={title} />
         </Flex>
         <Divider />
         <ProductInfo

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -76,7 +76,7 @@ const ProductDetail = ({
         <GoBackIcon />
       </Box>
       <Box
-        z-index="1"
+        z-index="10"
         position="absolute"
         right="15px"
         top="20px"

--- a/types/product/index.ts
+++ b/types/product/index.ts
@@ -5,6 +5,7 @@ export interface CardProductData {
   title: string;
   thumbnailImage: string;
   minimumPrice: number;
+  heartCount: number;
   expireAt: Date;
   createdAt: Date;
   updatedAt: Date;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 메인 페이지에서 찜한 사람 횟수 API 연동 및 구현
- [x] 상세 페이지에서 찜하기와 찜 취소하기 API 연동

# 작업 진행 사항
- 메인페이지에서의 찜 개수 받아오는 UI
<img width="400" alt="image" src="https://user-images.githubusercontent.com/50071076/184529796-2aa23d50-b49a-4ff9-821a-d8774b539918.png">

- 찜 했을 경우 Toast
<img width="400" alt="image" src="https://user-images.githubusercontent.com/50071076/184529822-195e5c71-6ee0-472f-a14e-4d173e3e2f45.png">

# 관련 이슈
- 현재 찜 취소하기는 테스트 해볼 수 없는 상황입니다! 유저가 이미 찜을 했는지 안했는지를 알 수가 없어 우선 API를 연동만 해놓았습니다!
- 찜 했을 경우와 찜 취소했을 경우에 `Toast`를 보여주는 것이 맞는지 잘 모르겠습니다. 실제 서비스에서는 단지 아이콘의 색칠 여부에 따라만 판단하지 않을까 싶어서요! 이부분에서 다들 의견 부탁드리겠습니다.
  - 아이콘 색칠: 찜 함, 아이콘 색이 비어있음: 찜하지 않음
  
- TODO: 유저가 찜을 했는지에 대한 여부에 따라 찜 하기와 찜 취소하기 분기 처리를 해야합니다.

- 재호님 다음 기능: 유저에서 찜하기 불러오기! 제대로 호출되는지 확인했습니다!
<img width="400" alt="image" src="https://user-images.githubusercontent.com/50071076/184530036-568c06dd-4bca-4e8d-884d-2bbfe58e7e43.png">

# 중점적으로 봐줬으면 하는 부분
- 함수명, 변수명, 컴포넌트명 확인 부탁드립니다!
- `handleHeartClick` 메서드에서 분기 처리가 있는데 더 깔끔하게 작성할 방법이 없을까요? 많은 의견 부탁드립니다!