### PR TITLE
[BM-303] 채팅 페이지 레이아웃 구현

### DIFF
--- a/components/ChatRoom/ChatDateBox.tsx
+++ b/components/ChatRoom/ChatDateBox.tsx
@@ -1,0 +1,25 @@
+import { Center, Text } from '@chakra-ui/react';
+
+const ChatDateBox = () => {
+  return (
+    <Center
+      bgColor="brand.primary-100"
+      borderRadius="30px"
+      width="107px"
+      height="25px"
+    >
+      <Text
+        color="#FF7898"
+        fontFamily="Roboto"
+        fontStyle="normal"
+        fontWeight="400"
+        fontSize="13px"
+        lineHeight="15px"
+      >
+        2022년 8월 14일
+      </Text>
+    </Center>
+  );
+};
+
+export default ChatDateBox;

--- a/components/ChatRoom/ChatDateBox.tsx
+++ b/components/ChatRoom/ChatDateBox.tsx
@@ -1,5 +1,6 @@
 import { Center, Text } from '@chakra-ui/react';
 
+// TODO: 메세지 날짜별로 구분하고 날짜를 prop으로 받기
 const ChatDateBox = () => {
   return (
     <Center

--- a/components/ChatRoom/ChatInput.tsx
+++ b/components/ChatRoom/ChatInput.tsx
@@ -1,0 +1,40 @@
+import { Input } from '@chakra-ui/react';
+
+interface ChatInputProps {
+  onSubmit: (nextMessage: string) => void;
+}
+
+const ChatInput = ({ onSubmit }: ChatInputProps) => {
+  const handleKeyup = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      const target = e.target as HTMLInputElement;
+
+      onSubmit(target.value);
+      target.value = '';
+
+      return;
+    }
+  };
+
+  return (
+    <Input
+      width="100%"
+      height="48px"
+      bgColor="#EFEFEF"
+      border="0.7px solid #EFEFEF"
+      borderRadius="30px"
+      placeholder="메세지를 입력해주세요."
+      _placeholder={{
+        color: '#ACACAC',
+        fontFamily: 'Inter',
+        fontStyle: 'normal',
+        fontWeight: '400',
+        fontSize: '15px',
+        lineHeight: '120%',
+      }}
+      onKeyUp={handleKeyup}
+    />
+  );
+};
+
+export default ChatInput;

--- a/components/ChatRoom/ChatInput.tsx
+++ b/components/ChatRoom/ChatInput.tsx
@@ -1,11 +1,13 @@
-import { Input } from '@chakra-ui/react';
+import { ArrowUpIcon } from '@chakra-ui/icons';
+import { Input, InputGroup, InputRightElement } from '@chakra-ui/react';
+import { useState } from 'react';
 
 interface ChatInputProps {
   onSubmit: (nextMessage: string) => void;
 }
 
-// TODO: 비행기? 아이콘 추가 왼쪽에 + 버튼도??
 const ChatInput = ({ onSubmit }: ChatInputProps) => {
+  const [visible, setVisible] = useState(true);
   const handleKeyup = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       const target = e.target as HTMLInputElement;
@@ -18,23 +20,33 @@ const ChatInput = ({ onSubmit }: ChatInputProps) => {
   };
 
   return (
-    <Input
-      width="100%"
-      height="48px"
-      bgColor="#EFEFEF"
-      border="0.7px solid #EFEFEF"
-      borderRadius="30px"
-      placeholder="메세지를 입력해주세요."
-      _placeholder={{
-        color: '#ACACAC',
-        fontFamily: 'Inter',
-        fontStyle: 'normal',
-        fontWeight: '400',
-        fontSize: '15px',
-        lineHeight: '120%',
-      }}
-      onKeyUp={handleKeyup}
-    />
+    <InputGroup size="md">
+      <Input
+        width="100%"
+        height="48px"
+        bgColor="#EFEFEF"
+        border="0.7px solid #EFEFEF"
+        borderRadius="30px"
+        placeholder="메세지를 입력해주세요."
+        _placeholder={{
+          color: '#ACACAC',
+          fontFamily: 'Inter',
+          fontStyle: 'normal',
+          fontWeight: '400',
+          fontSize: '15px',
+          lineHeight: '120%',
+        }}
+        focusBorderColor="brand.primary-900"
+        onFocus={() => setVisible(false)}
+        onBlur={() => setVisible(true)}
+        onKeyUp={handleKeyup}
+      />
+      {visible && (
+        <InputRightElement pointerEvents="none" paddingRight="16px">
+          <ArrowUpIcon width="22px" height="22px" alignSelf="center" />
+        </InputRightElement>
+      )}
+    </InputGroup>
   );
 };
 

--- a/components/ChatRoom/ChatInput.tsx
+++ b/components/ChatRoom/ChatInput.tsx
@@ -4,6 +4,7 @@ interface ChatInputProps {
   onSubmit: (nextMessage: string) => void;
 }
 
+// TODO: 비행기? 아이콘 추가 왼쪽에 + 버튼도??
 const ChatInput = ({ onSubmit }: ChatInputProps) => {
   const handleKeyup = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {

--- a/components/ChatRoom/ChatTimeText.tsx
+++ b/components/ChatRoom/ChatTimeText.tsx
@@ -1,0 +1,26 @@
+import { Box, Text } from '@chakra-ui/react';
+
+import chatTimeFormat from 'utils/format/chatTimeFormat';
+
+interface ChatTimeTextProps {
+  createdAt: Date;
+}
+
+const ChatTimeText = ({ createdAt }: ChatTimeTextProps) => {
+  return (
+    <Box alignSelf="flex-end">
+      <Text
+        color="#A6A6A6"
+        fontFamily="Inter"
+        fontStyle="normal"
+        fontWeight="400"
+        fontSize="12px"
+        lineHeight="15px"
+      >
+        {chatTimeFormat(new Date(createdAt))}
+      </Text>
+    </Box>
+  );
+};
+
+export default ChatTimeText;

--- a/components/ChatRoom/MessageList.tsx
+++ b/components/ChatRoom/MessageList.tsx
@@ -1,0 +1,34 @@
+import { Flex } from '@chakra-ui/react';
+
+import { ChatMeesageResponseType } from 'types/chatMessages';
+
+import { RecievedMessage, SendingMessage } from '.';
+
+interface MessageListProps {
+  userId: number;
+  messages: ChatMeesageResponseType;
+}
+
+const MessageList = ({ userId, messages }: MessageListProps) => {
+  return (
+    <Flex width="100%" height="100%" flexDirection="column" gap="16px">
+      {messages.map(({ userInfo, content, createdAt }, index) =>
+        userId === userInfo.userId ? (
+          <Flex key={index} width="100%">
+            <SendingMessage content={content} createdAt={createdAt} />
+          </Flex>
+        ) : (
+          <Flex key={index} width="100%">
+            <RecievedMessage
+              userInfo={userInfo}
+              content={content}
+              createdAt={createdAt}
+            />
+          </Flex>
+        )
+      )}
+    </Flex>
+  );
+};
+
+export default MessageList;

--- a/components/ChatRoom/RecievedMessage.tsx
+++ b/components/ChatRoom/RecievedMessage.tsx
@@ -1,11 +1,11 @@
 import { Avatar, Box, Flex, Text } from '@chakra-ui/react';
 
-import { User } from 'types/user';
+import { UserInfo } from 'types/user';
 
 import { ChatTimeText } from '.';
 
 interface RecievedMessageProps {
-  userInfo: User;
+  userInfo: UserInfo;
   content: string;
   createdAt: Date;
 }

--- a/components/ChatRoom/RecievedMessage.tsx
+++ b/components/ChatRoom/RecievedMessage.tsx
@@ -1,0 +1,61 @@
+import { Avatar, Box, Flex, Text } from '@chakra-ui/react';
+
+import { User } from 'types/user';
+
+import { ChatTimeText } from '.';
+
+interface RecievedMessageProps {
+  userInfo: User;
+  content: string;
+  createdAt: Date;
+}
+
+const RecievedMessage = ({
+  userInfo,
+  content,
+  createdAt,
+}: RecievedMessageProps) => {
+  return (
+    <Flex width="100%" justifyContent="flex-start" alignItems="center">
+      <Avatar
+        alignSelf="flex-start"
+        src={userInfo.profileImage}
+        marginRight="10px"
+      />
+      <Flex
+        alignSelf="flex-start"
+        flexDirection="column"
+        maxWidth="55%"
+        marginRight="4px"
+      >
+        <Text
+          fontFamily="Inter"
+          fontWeight="700"
+          fontSize="14px"
+          lineHeight="16.8px"
+        >
+          {userInfo.username}
+        </Text>
+        <Box
+          maxWidth="100%"
+          bgColor="#EFEFEF"
+          borderRadius="0px 20px 20px 20px"
+          padding="12px 16px 12px 16px"
+        >
+          <Text
+            color="brand.dark"
+            fontFamily="Inter"
+            fontWeight="400"
+            fontSize="15px"
+            lineHeight="21px"
+          >
+            {content}
+          </Text>
+        </Box>
+      </Flex>
+      <ChatTimeText createdAt={createdAt} />
+    </Flex>
+  );
+};
+
+export default RecievedMessage;

--- a/components/ChatRoom/SendingMessage.tsx
+++ b/components/ChatRoom/SendingMessage.tsx
@@ -9,7 +9,12 @@ interface SendingMessageProps {
 
 const SendingMessage = ({ content, createdAt }: SendingMessageProps) => {
   return (
-    <Flex width="100%" justifyContent="flex-end" alignItems="center">
+    <Flex
+      width="100%"
+      justifyContent="flex-end"
+      alignItems="center"
+      paddingRight="1px"
+    >
       <ChatTimeText createdAt={createdAt} />
       <Box
         maxWidth="55%"

--- a/components/ChatRoom/SendingMessage.tsx
+++ b/components/ChatRoom/SendingMessage.tsx
@@ -1,0 +1,34 @@
+import { Box, Flex, Text } from '@chakra-ui/react';
+
+import { ChatTimeText } from '.';
+
+interface SendingMessageProps {
+  content: string;
+  createdAt: Date;
+}
+
+const SendingMessage = ({ content, createdAt }: SendingMessageProps) => {
+  return (
+    <Flex width="100%" gap="16px" justifyContent="flex-end" alignItems="center">
+      <ChatTimeText createdAt={createdAt} />
+      <Box
+        maxWidth="55%"
+        bgColor=" #FF4370"
+        borderRadius="0px 20px 20px 20px"
+        padding="12px 16px 12px 16px"
+      >
+        <Text
+          color="white"
+          fontFamily="Inter"
+          fontWeight="400"
+          fontSize="15px"
+          lineHeight="21px"
+        >
+          {content}
+        </Text>
+      </Box>
+    </Flex>
+  );
+};
+
+export default SendingMessage;

--- a/components/ChatRoom/SendingMessage.tsx
+++ b/components/ChatRoom/SendingMessage.tsx
@@ -9,13 +9,14 @@ interface SendingMessageProps {
 
 const SendingMessage = ({ content, createdAt }: SendingMessageProps) => {
   return (
-    <Flex width="100%" gap="16px" justifyContent="flex-end" alignItems="center">
+    <Flex width="100%" justifyContent="flex-end" alignItems="center">
       <ChatTimeText createdAt={createdAt} />
       <Box
         maxWidth="55%"
         bgColor=" #FF4370"
-        borderRadius="0px 20px 20px 20px"
+        borderRadius="20px 0px 20px 20px"
         padding="12px 16px 12px 16px"
+        marginLeft="4px"
       >
         <Text
           color="white"

--- a/components/ChatRoom/index.tsx
+++ b/components/ChatRoom/index.tsx
@@ -1,1 +1,3 @@
 export { default as ChatDateBox } from './ChatDateBox';
+export { default as SendingMessage } from './SendingMessage';
+export { default as ChatTimeText } from './ChatTimeText';

--- a/components/ChatRoom/index.tsx
+++ b/components/ChatRoom/index.tsx
@@ -2,3 +2,4 @@ export { default as ChatDateBox } from './ChatDateBox';
 export { default as RecievedMessage } from './RecievedMessage';
 export { default as SendingMessage } from './SendingMessage';
 export { default as ChatTimeText } from './ChatTimeText';
+export { default as ChatInput } from './ChatInput';

--- a/components/ChatRoom/index.tsx
+++ b/components/ChatRoom/index.tsx
@@ -1,0 +1,1 @@
+export { default as ChatDateBox } from './ChatDateBox';

--- a/components/ChatRoom/index.tsx
+++ b/components/ChatRoom/index.tsx
@@ -1,3 +1,4 @@
 export { default as ChatDateBox } from './ChatDateBox';
+export { default as RecievedMessage } from './RecievedMessage';
 export { default as SendingMessage } from './SendingMessage';
 export { default as ChatTimeText } from './ChatTimeText';

--- a/components/ChatRoom/index.tsx
+++ b/components/ChatRoom/index.tsx
@@ -3,3 +3,4 @@ export { default as RecievedMessage } from './RecievedMessage';
 export { default as SendingMessage } from './SendingMessage';
 export { default as ChatTimeText } from './ChatTimeText';
 export { default as ChatInput } from './ChatInput';
+export { default as MessageList } from './MessageList';

--- a/hooks/useStomp.ts
+++ b/hooks/useStomp.ts
@@ -4,14 +4,14 @@ import { Dispatch, SetStateAction, useCallback } from 'react';
 import SockJS from 'sockjs-client';
 
 import { ChatMeesageResponseType } from 'types/chatMessages';
-import { User } from 'types/user';
+import { UserInfo } from 'types/user';
 
 const { publicRuntimeConfig } = getConfig();
 let client: Client | null = null;
 
 export interface UseStompProps {
   chatRoomId: number;
-  userInfo: User;
+  userInfo: UserInfo;
   setMessages: Dispatch<SetStateAction<ChatMeesageResponseType>>;
 }
 
@@ -72,7 +72,7 @@ const useStomp = ({ chatRoomId, userInfo, setMessages }: UseStompProps) => {
 
       client?.publish({
         destination: `/message/room/${chatRoomId}`,
-        body: JSON.stringify({ userId: userInfo.id, content: message }),
+        body: JSON.stringify({ userId: userInfo.userId, content: message }),
       });
     },
     [chatRoomId, userInfo]

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -95,11 +95,17 @@ const ChatRoom: NextPage = ({
         <Flex flexDirection="column" flexGrow="1">
           <MessageList userId={user.id} messages={messages} />
         </Flex>
-        <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
-          <ChatInput onSubmit={publish} />
-        </Flex>
-        <div ref={lastRef} />
       </Flex>
+      <Flex
+        position="sticky"
+        bottom="0px"
+        width="100%"
+        marginTop="16px"
+        bgColor="white"
+      >
+        <ChatInput onSubmit={publish} />
+      </Flex>
+      <div ref={lastRef} />
     </Flex>
   );
 };

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -15,17 +15,17 @@ import { ChatMeesageResponseType } from 'types/chatMessages';
 export const getServerSideProps: GetServerSideProps = async ({
   query: { userId, chatRoomId, chattingUsername = '' },
 }) => {
-  let userInfo = {};
+  let user = {};
 
   try {
-    userInfo = (await userAPI.getUser(parseInt(userId as string, 10))).data;
+    user = (await userAPI.getUser(parseInt(userId as string, 10))).data;
   } catch (error) {
     console.error(error);
   }
 
   return {
     props: {
-      userInfo,
+      user,
       chatRoomId: parseInt(chatRoomId as string, 10),
       chattingUsername,
     },
@@ -33,7 +33,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 };
 
 const ChatRoom: NextPage = ({
-  userInfo,
+  user,
   chatRoomId,
   chattingUsername,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
@@ -41,9 +41,9 @@ const ChatRoom: NextPage = ({
   const { connect, disConnect, publish } = useStomp({
     chatRoomId,
     userInfo: {
-      userId: userInfo.id,
-      username: userInfo.username,
-      profileImage: userInfo.profileImage,
+      userId: user.id,
+      username: user.username,
+      profileImage: user.profileImage,
     },
     setMessages,
   });
@@ -93,7 +93,7 @@ const ChatRoom: NextPage = ({
           <ChatDateBox />
         </Center>
         <Flex flexDirection="column" flexGrow="1">
-          <MessageList userId={userInfo.id} messages={messages} />
+          <MessageList userId={user.id} messages={messages} />
         </Flex>
         <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
           <ChatInput onSubmit={publish} />

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -4,7 +4,7 @@ import {
   InferGetServerSidePropsType,
   NextPage,
 } from 'next';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { userAPI } from 'apis';
 import {
@@ -46,6 +46,7 @@ const ChatRoom: NextPage = ({
     userInfo,
     setMessages,
   });
+  const lastRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     connect();
@@ -68,6 +69,17 @@ const ChatRoom: NextPage = ({
 
     setMessages([...chatMessages.reverse(), ...messages]);
   };
+
+  useEffect(() => {
+    if (!lastRef.current) {
+      return;
+    }
+
+    lastRef.current.scrollIntoView({
+      behavior: 'smooth',
+      block: 'end',
+    });
+  }, [lastRef, messages]);
 
   return (
     <Flex flexDirection="column">
@@ -96,9 +108,10 @@ const ChatRoom: NextPage = ({
             );
           }
         )}
-      </Flex>
-      <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
-        <ChatInput onSubmit={publish} />
+        <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
+          <ChatInput onSubmit={publish} />
+        </Flex>
+        <div ref={lastRef} />
       </Flex>
     </Flex>
   );

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -1,4 +1,4 @@
-import { Center, Flex, Input, Text } from '@chakra-ui/react';
+import { Center, Flex, Input } from '@chakra-ui/react';
 import {
   GetServerSideProps,
   InferGetServerSidePropsType,
@@ -7,7 +7,7 @@ import {
 import { useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
-import { ChatDateBox } from 'components/ChatRoom';
+import { ChatDateBox, SendingMessage } from 'components/ChatRoom';
 import { GoBackIcon, Header, HeaderTitle } from 'components/common';
 import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
@@ -85,10 +85,8 @@ const ChatRoom: NextPage = ({
           <ChatDateBox />
         </Center>
         {messages.map(({ userInfo, content, createdAt }, index) => (
-          <Flex key={index} flexDirection="row" gap={'16px'}>
-            <Text>{userInfo.username}</Text>
-            <Text color="red">{content}</Text>
-            <Text>{String(createdAt)}</Text>
+          <Flex key={index} width="100%">
+            <SendingMessage content={content} createdAt={createdAt} />
           </Flex>
         ))}
       </Flex>

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -82,6 +82,7 @@ const ChatRoom: NextPage = ({
     });
   }, [lastRef, messages]);
 
+  // TODO: ... 아이콘에 채팅방 나가기, 신고하기 기능
   return (
     <Flex flexDirection="column">
       <Header

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -88,32 +88,33 @@ const ChatRoom: NextPage = ({
 
   // TODO: ... 아이콘에 채팅방 나가기, 신고하기 기능
   return (
-    <Flex width="100%" flexDirection="column">
+    <Flex width="100%" height="100%" flexDirection="column">
       <Header
         leftContent={<GoBackIcon />}
         middleContent={<HeaderTitle title={chattingUsername} />}
       />
-      <Flex flexDirection="column" gap={'16px'}>
+      <Flex height="100%" flexDirection="column" gap="16px">
         <Center>
           <ChatDateBox />
         </Center>
-        {messages.map(
-          ({ userInfo: userInfoInMessage, content, createdAt }, index) => {
-            return userInfo.id === userInfoInMessage.userId ? (
-              <Flex key={index} width="100%">
-                <SendingMessage content={content} createdAt={createdAt} />
-              </Flex>
-            ) : (
-              <Flex key={index} width="100%">
-                <RecievedMessage
-                  userInfo={userInfoInMessage}
-                  content={content}
-                  createdAt={createdAt}
-                />
-              </Flex>
-            );
-          }
-        )}
+        <Flex flexDirection="column" flexGrow="1" gap="16px">
+          {messages.map(
+            ({ userInfo: userInfoInMessage, content, createdAt }, index) =>
+              userInfo.id === userInfoInMessage.userId ? (
+                <Flex key={index} width="100%">
+                  <SendingMessage content={content} createdAt={createdAt} />
+                </Flex>
+              ) : (
+                <Flex key={index} width="100%">
+                  <RecievedMessage
+                    userInfo={userInfoInMessage}
+                    content={content}
+                    createdAt={createdAt}
+                  />
+                </Flex>
+              )
+          )}
+        </Flex>
         <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
           <ChatInput onSubmit={publish} />
         </Flex>

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -7,12 +7,7 @@ import {
 import { useEffect, useRef, useState } from 'react';
 
 import { userAPI } from 'apis';
-import {
-  ChatDateBox,
-  ChatInput,
-  RecievedMessage,
-  SendingMessage,
-} from 'components/ChatRoom';
+import { ChatDateBox, ChatInput, MessageList } from 'components/ChatRoom';
 import { GoBackIcon, Header, HeaderTitle } from 'components/common';
 import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
@@ -97,23 +92,8 @@ const ChatRoom: NextPage = ({
         <Center>
           <ChatDateBox />
         </Center>
-        <Flex flexDirection="column" flexGrow="1" gap="16px">
-          {messages.map(
-            ({ userInfo: userInfoInMessage, content, createdAt }, index) =>
-              userInfo.id === userInfoInMessage.userId ? (
-                <Flex key={index} width="100%">
-                  <SendingMessage content={content} createdAt={createdAt} />
-                </Flex>
-              ) : (
-                <Flex key={index} width="100%">
-                  <RecievedMessage
-                    userInfo={userInfoInMessage}
-                    content={content}
-                    createdAt={createdAt}
-                  />
-                </Flex>
-              )
-          )}
+        <Flex flexDirection="column" flexGrow="1">
+          <MessageList userId={userInfo.id} messages={messages} />
         </Flex>
         <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
           <ChatInput onSubmit={publish} />

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -1,4 +1,4 @@
-import { Center, Flex, Input } from '@chakra-ui/react';
+import { Center, Flex } from '@chakra-ui/react';
 import {
   GetServerSideProps,
   InferGetServerSidePropsType,
@@ -9,6 +9,7 @@ import { useEffect, useState } from 'react';
 import { userAPI } from 'apis';
 import {
   ChatDateBox,
+  ChatInput,
   RecievedMessage,
   SendingMessage,
 } from 'components/ChatRoom';
@@ -68,17 +69,6 @@ const ChatRoom: NextPage = ({
     setMessages([...chatMessages.reverse(), ...messages]);
   };
 
-  const handleKeyup = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter') {
-      const target = e.target as HTMLInputElement;
-
-      publish(target.value);
-      target.value = '';
-
-      return;
-    }
-  };
-
   return (
     <Flex flexDirection="column">
       <Header
@@ -107,7 +97,9 @@ const ChatRoom: NextPage = ({
           }
         )}
       </Flex>
-      <Input onKeyUp={handleKeyup} />
+      <Flex position="sticky" bottom="0" width="100%" marginTop="16px">
+        <ChatInput onSubmit={publish} />
+      </Flex>
     </Flex>
   );
 };

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -18,7 +18,7 @@ import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
 
 export const getServerSideProps: GetServerSideProps = async ({
-  query: { userId, chatRoomId },
+  query: { userId, chatRoomId, chattingUsername },
 }) => {
   let userInfo = {};
 
@@ -32,6 +32,7 @@ export const getServerSideProps: GetServerSideProps = async ({
     props: {
       userInfo,
       chatRoomId: parseInt(chatRoomId as string, 10),
+      chattingUsername,
     },
   };
 };
@@ -39,6 +40,7 @@ export const getServerSideProps: GetServerSideProps = async ({
 const ChatRoom: NextPage = ({
   userInfo,
   chatRoomId,
+  chattingUsername,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const [messages, setMessages] = useState<ChatMeesageResponseType>([]);
   const { connect, disConnect, publish } = useStomp({
@@ -85,7 +87,7 @@ const ChatRoom: NextPage = ({
     <Flex flexDirection="column">
       <Header
         leftContent={<GoBackIcon />}
-        middleContent={<HeaderTitle title="유저네임" />}
+        middleContent={<HeaderTitle title={chattingUsername} />}
       />
       <Flex flexDirection="column" gap={'16px'}>
         <Center>

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, Input, Text } from '@chakra-ui/react';
+import { Center, Flex, Input, Text } from '@chakra-ui/react';
 import {
   GetServerSideProps,
   InferGetServerSidePropsType,
@@ -7,6 +7,8 @@ import {
 import { useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
+import { ChatDateBox } from 'components/ChatRoom';
+import { GoBackIcon, Header, HeaderTitle } from 'components/common';
 import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
 
@@ -73,9 +75,15 @@ const ChatRoom: NextPage = ({
   };
 
   return (
-    <Flex flexDirection="column" gap={'16px'}>
-      <h1>임시 채팅방이요!</h1>
+    <Flex flexDirection="column">
+      <Header
+        leftContent={<GoBackIcon />}
+        middleContent={<HeaderTitle title="유저네임" />}
+      />
       <Flex flexDirection="column" gap={'16px'}>
+        <Center>
+          <ChatDateBox />
+        </Center>
         {messages.map(({ userInfo, content, createdAt }, index) => (
           <Flex key={index} flexDirection="row" gap={'16px'}>
             <Text>{userInfo.username}</Text>

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -67,7 +67,6 @@ const ChatRoom: NextPage = ({
         limit: 100,
       })
     ).data;
-    console.log(chatMessages);
 
     setMessages([...chatMessages.reverse(), ...messages]);
   };

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -7,7 +7,11 @@ import {
 import { useEffect, useState } from 'react';
 
 import { userAPI } from 'apis';
-import { ChatDateBox, SendingMessage } from 'components/ChatRoom';
+import {
+  ChatDateBox,
+  RecievedMessage,
+  SendingMessage,
+} from 'components/ChatRoom';
 import { GoBackIcon, Header, HeaderTitle } from 'components/common';
 import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
@@ -59,6 +63,7 @@ const ChatRoom: NextPage = ({
         limit: 100,
       })
     ).data;
+    console.log(chatMessages);
 
     setMessages([...chatMessages.reverse(), ...messages]);
   };
@@ -84,13 +89,24 @@ const ChatRoom: NextPage = ({
         <Center>
           <ChatDateBox />
         </Center>
-        {messages.map(({ userInfo, content, createdAt }, index) => (
-          <Flex key={index} width="100%">
-            <SendingMessage content={content} createdAt={createdAt} />
-          </Flex>
-        ))}
+        {messages.map(
+          ({ userInfo: userInfoInMessage, content, createdAt }, index) => {
+            return userInfo.id === userInfoInMessage.userId ? (
+              <Flex key={index} width="100%">
+                <SendingMessage content={content} createdAt={createdAt} />
+              </Flex>
+            ) : (
+              <Flex key={index} width="100%">
+                <RecievedMessage
+                  userInfo={userInfoInMessage}
+                  content={content}
+                  createdAt={createdAt}
+                />
+              </Flex>
+            );
+          }
+        )}
       </Flex>
-
       <Input onKeyUp={handleKeyup} />
     </Flex>
   );

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -18,7 +18,7 @@ import useStomp from 'hooks/useStomp';
 import { ChatMeesageResponseType } from 'types/chatMessages';
 
 export const getServerSideProps: GetServerSideProps = async ({
-  query: { userId, chatRoomId, chattingUsername },
+  query: { userId, chatRoomId, chattingUsername = '' },
 }) => {
   let userInfo = {};
 
@@ -45,7 +45,11 @@ const ChatRoom: NextPage = ({
   const [messages, setMessages] = useState<ChatMeesageResponseType>([]);
   const { connect, disConnect, publish } = useStomp({
     chatRoomId,
-    userInfo,
+    userInfo: {
+      userId: userInfo.id,
+      username: userInfo.username,
+      profileImage: userInfo.profileImage,
+    },
     setMessages,
   });
   const lastRef = useRef<HTMLDivElement>(null);
@@ -84,7 +88,7 @@ const ChatRoom: NextPage = ({
 
   // TODO: ... 아이콘에 채팅방 나가기, 신고하기 기능
   return (
-    <Flex flexDirection="column">
+    <Flex width="100%" flexDirection="column">
       <Header
         leftContent={<GoBackIcon />}
         middleContent={<HeaderTitle title={chattingUsername} />}

--- a/pages/user/[userId]/chat/index.tsx
+++ b/pages/user/[userId]/chat/index.tsx
@@ -92,7 +92,19 @@ const Chats: NextPage = ({
                 previewChat={lastMessage}
                 productImage={productInfo.thumbnailImage}
                 createdAt={new Date(lastMessageDate)}
-                onClick={() => router.push(`/user/${id}/chat/${chatRoomId}`)}
+                onClick={() =>
+                  router.push(
+                    {
+                      pathname: `/user/${id}/chat/${chatRoomId}`,
+                      query: {
+                        id,
+                        chatRoomId,
+                        chattingUsername: opponentUserInfo.username,
+                      },
+                    },
+                    `/user/${id}/chat/${chatRoomId}`
+                  )
+                }
               />
               <Divider />
             </Fragment>

--- a/types/chatMessages/index.ts
+++ b/types/chatMessages/index.ts
@@ -1,7 +1,7 @@
-import { User } from 'types/user';
+import { UserInfo } from 'types/user';
 
 export interface ChatMessageData {
-  userInfo: User;
+  userInfo: UserInfo;
   content: string;
   createdAt: Date;
 }

--- a/types/user/index.ts
+++ b/types/user/index.ts
@@ -3,3 +3,9 @@ export interface User {
   username: string;
   profileImage: string;
 }
+
+export interface UserInfo {
+  userId: number;
+  username: string;
+  profileImage: string;
+}

--- a/utils/format/chatTimeFormat.ts
+++ b/utils/format/chatTimeFormat.ts
@@ -1,0 +1,10 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+/**
+ *  오후 1:22
+ */
+const chatTimeFormat = (createdAt: Date) =>
+  format(new Date(createdAt), 'aaaaa h:mm', { locale: ko });
+
+export default chatTimeFormat;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 채팅 페이지 레이아웃 구현
- [x] 채팅 페이지 제목에 상대방 이름 표시
- [x] 메세지 변화시 스크롤 아래로 이동  

# 작업 진행 사항

https://user-images.githubusercontent.com/16220817/184533133-83ad65ab-ccf7-4fb0-ae71-3b411427fee1.mov


# 관련 이슈
- 처음 api로 전달 받은 메세지들을 날짜 별로 구분하고 그 메세지를 렌더링해야함.
- ... 메뉴 추가 및 채팅방 나가기, 신고하기 기능 추가
- input 창 figma 아이콘 적용 못함(왼쪽 + 아이콘은 필요할지?)
- ~채팅 메세지 `userInfo`에 `userId`로 내려오는데 `id`로 변경될지 마틴에게 물어볼 예정. (`User` 타입과 일치시키기 위해)~
- +) 채팅페이지에서는 실시간으로 메세지를 받을 수 있는데 채팅방 목록에서는 어떻게 갱신 시킬지 (처음 api로 목록만 받아옴)

# 중점적으로 봐줬으면 하는 부분
input창 아이콘 svg로 어떻게 받아오나요? 😭

<img width="307" alt="스크린샷 2022-08-14 오후 7 39 56" src="https://user-images.githubusercontent.com/16220817/184533141-8117e80e-b5ce-48e1-ae47-684be396611a.png">
