### PR TITLE
[BM-350] 유저 찜 여부에 따른 API 분기처리와 ProductCard 컴포넌트 스타일 수정

### DIFF
--- a/apis/api/heart/index.tsx
+++ b/apis/api/heart/index.tsx
@@ -1,10 +1,10 @@
 import { authInstance } from 'apis/utils/authInstance';
 
 const heartAPI = {
-  putHeart: (userId: number, productId: number) =>
-    authInstance.put(`/users/${productId}/hearts`, { userId, productId }),
-  deleteHeart: (productId: number) =>
-    authInstance.delete(`/users/${productId}/hearts`),
+  getHeartAuthUser: (productId: number) =>
+    authInstance.get(`/users/${productId}/hearts`),
+  updateHeart: (productId: number) =>
+    authInstance.put(`/users/${productId}/hearts`),
 };
 
 export default heartAPI;

--- a/components/ProductDetail/ProductHeart.tsx
+++ b/components/ProductDetail/ProductHeart.tsx
@@ -49,11 +49,10 @@ const ProductHeart = ({ productId, userId, title }: ProductHeartProps) => {
       await heartAPI.updateHeart(productId);
       setIsHeartHeartProduct(!isHeartProduct);
 
-      isHeartProduct
-        ? toast(
-            setToastInfo('top', `${title}의 찜을 취소하였습니다.`, 'success')
-          )
-        : toast(setToastInfo('top', `${title}를 찜했습니다!`, 'success'));
+      const toastContent = isHeartProduct
+        ? `${title}의 찜을 취소하였습니다.`
+        : `${title}를 찜했습니다!`;
+      toast(setToastInfo('top', toastContent, 'success'));
     } catch (error) {
       console.log(error);
     }

--- a/components/ProductDetail/ProductHeart.tsx
+++ b/components/ProductDetail/ProductHeart.tsx
@@ -36,11 +36,12 @@ const ProductHeart = ({ productId, userId, title }: ProductHeartProps) => {
   };
 
   const checkLoginAuthUser = () => {
-    if (userId === -1) {
-      toast(setToastInfo('top', '찜은 로그인 후 이용 가능합니다.', 'warning'));
-      router.push('/login');
+    if (userId !== -1) {
       return;
     }
+
+    toast(setToastInfo('top', '찜은 로그인 후 이용 가능합니다.', 'warning'));
+    router.push('/login');
   };
 
   const toggleHeartProduct = async () => {

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -19,8 +19,8 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
   return (
     <Flex
       padding="15px 0"
-      width="100%"
-      height="144px"
+      w="100%"
+      h="144px"
       cursor="pointer"
       onClick={() => router.push(`/products/${id}`)}
     >
@@ -28,8 +28,21 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
         alt={`${id}-product-image`}
         src={thumbnailImage || '/svg/basket.svg'}
       />
-      <Flex direction="column" paddingLeft="15px" width="100%" gap="5px">
-        <Text fontSize="lg">{title}</Text>
+      <Flex
+        direction="column"
+        paddingLeft="15px"
+        w="100%"
+        gap="5px"
+        overflow="hidden"
+      >
+        <Text
+          fontSize="lg"
+          whiteSpace="nowrap"
+          overflow="hidden"
+          textOverflow="ellipsis"
+        >
+          {title}
+        </Text>
         <Flex justifyContent="space-between" alignItems="center">
           <Text fontSize="sm" color="brand.primary-900">
             시작가


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] ProductCard
- [x] 상세페이지 유저 찜 여부를 알 수 있는 API 연동 및 구현
- [x] 찜하기, 찜 취소하기 구현 리팩토링 

# 작업 진행 사항
- Card 타이틀이 길 경우 `...`으로 표시되도록 변경(stark 도움)
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/184545297-ebbfdc2f-c09f-436b-89be-ee776eb3145c.png">

- 전자레인지 상품에 1명이 찜했을 경우
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/184545417-f29572cd-a367-4c4d-b5a6-1cc909b95b68.png">

- 위의 전자레인지 상품 상세로 들어갔을 때 
<img width="300" alt="image" src="https://user-images.githubusercontent.com/50071076/184545460-77a341a7-afb2-4a93-b8d3-528c88a636d3.png">

- 찜하기, 찜 취소하기
[이전 PR](https://github.com/prgrms-web-devcourse/Team-Saiko-BidMarket-FE/pull/66)에 자세히 적어놓았습니다.

# 관련 이슈
- 없습니다!

# 중점적으로 봐줬으면 하는 부분
- 함수명, 변수명, API 메서드 명 확인 부탁드립니다!