### PR TITLE
[BM-351] 만료 후 1분 배치 시간 동안 사용자 메시지 출력 버그 픽스

### DIFF
--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -63,6 +63,8 @@ const ProductBid = ({
   });
   const [isCalculatingBiddingResult, setIsCalculatingBiddingResult] =
     useState(false);
+  const [isExpiredAndCalculatedBidding, setIsExpiredAndCalculatedBidding] =
+    useState(false);
 
   useEffect(() => {
     if (isExpiredBidding) {
@@ -122,12 +124,13 @@ const ProductBid = ({
 
     setTimeout(() => {
       setIsCalculatingBiddingResult(false);
+      setIsExpiredAndCalculatedBidding(true);
       router.reload();
     }, remainedBiddingTime + MINUTE_TO_SECONDS);
   };
 
   const isShowBiddingEndText = () => {
-    return isExpiredBidding && (isSeller || bidder.biddingSucceed);
+    return isExpiredAndCalculatedBidding && (isSeller || bidder.biddingSucceed);
   };
 
   const isBidButtonDisabled = () => {


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 만료 후 1분 배치 시간 동안 사용자 메시지 출력 버그 픽스

# 작업 진행 사항
만료 후 1분 배치 시간 동안 판매자 메시지 부분이 보이지 않아야 하지만 보이는 버그를 수정하였습니다.

# 관련 이슈
없습니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.