### PR TITLE
[BM-332] 회원 정보 찜한 상품 페이지 API 연동 및 무한 스크롤 적용

### DIFF
--- a/apis/api/user/index.ts
+++ b/apis/api/user/index.ts
@@ -16,6 +16,11 @@ interface GetBiddingProductsType {
   sort?: string;
 }
 
+interface GetLikeProductsType {
+  offset: number;
+  sort?: string;
+}
+
 interface GetChatRoomMessagesType {
   chatRoomId: number;
   offset: number;
@@ -39,6 +44,10 @@ const userAPI = {
   }: GetBiddingProductsType) =>
     authInstance.get<ProductsResponseType>(
       `/users/biddings?offset=${offset}&limit=10&sort=${sort}`
+    ),
+  getLikeProducts: ({ offset, sort = 'END_DATE_ASC' }: GetLikeProductsType) =>
+    authInstance.get<ProductsResponseType>(
+      `/users/hearts?offset=${offset}&limit=10&sort=${sort}`
     ),
   getChatRooms: (offset: number, limit: number) =>
     authInstance.get<ChatRoomResponseType>(

--- a/hooks/queries/index.ts
+++ b/hooks/queries/index.ts
@@ -2,6 +2,7 @@ import useGetNotifications from './notification/useGetNotifications';
 import useGetProducts from './product/useGetProducts';
 import useGetProductsByKeyword from './product/useGetProductsByKeyword';
 import useGetUserBidProducts from './user/useGetUserBidProducts';
+import useGetUserLikeProducts from './user/useGetUserLikeProducts';
 import useGetUserSellProducts from './user/useGetUserSellProducts';
 
 export {
@@ -10,4 +11,5 @@ export {
   useGetNotifications,
   useGetUserBidProducts,
   useGetUserSellProducts,
+  useGetUserLikeProducts,
 };

--- a/hooks/queries/user/useGetUserLikeProducts.ts
+++ b/hooks/queries/user/useGetUserLikeProducts.ts
@@ -1,0 +1,29 @@
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+import { userAPI } from 'apis';
+
+const LIMIT = 10;
+
+const getUserLikeProductsAPI = async ({ pageParam = 0 }) => {
+  const { data } = await userAPI.getLikeProducts({ offset: pageParam });
+
+  return {
+    data,
+    currentPage: pageParam,
+    isLast: data.length ? false : true,
+  };
+};
+
+const useGetUserLikeProducts = () => {
+  return useInfiniteQuery(['products'], getUserLikeProductsAPI, {
+    getNextPageParam: (lastPage) => {
+      if (lastPage.isLast) {
+        return undefined;
+      }
+
+      return lastPage.currentPage + LIMIT;
+    },
+  });
+};
+
+export default useGetUserLikeProducts;

--- a/pages/user/[userId]/products/like/index.tsx
+++ b/pages/user/[userId]/products/like/index.tsx
@@ -1,27 +1,106 @@
-import { Center, Text } from '@chakra-ui/react';
-import type { NextPage } from 'next';
+import { Center, Spinner, Text } from '@chakra-ui/react';
+import type {
+  GetServerSideProps,
+  InferGetServerSidePropsType,
+  NextPage,
+} from 'next';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
 
-import { GoBackIcon, Header, HeaderTitle, SEO } from 'components/common';
+import { userAPI } from 'apis';
+import {
+  GoBackIcon,
+  Header,
+  HeaderTitle,
+  ProductCardContainer,
+  SEO,
+} from 'components/common';
 import { NoProducts } from 'components/User';
+import { useGetUserLikeProducts } from 'hooks/queries';
+import useLoginUser from 'hooks/useLoginUser';
 
-// @ TODO 데이터 가져와서 연결 작업
-const DUMMY = [];
+export const getServerSideProps: GetServerSideProps = async ({ query }) => {
+  const { userId } = query;
+  let user = {};
 
-const Like: NextPage = () => {
+  try {
+    user = (await userAPI.getUser(parseInt(userId as string, 10))).data;
+  } catch (error) {
+    console.error(error);
+  }
+
+  return {
+    props: {
+      user,
+    },
+  };
+};
+
+const Like: NextPage = ({
+  user: { id, username },
+}: InferGetServerSidePropsType<typeof getServerSideProps>) => {
+  const router = useRouter();
+  const userId = parseInt(id, 10);
+  const { id: authUserId } = useLoginUser();
+  const {
+    data: productPages,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetUserLikeProducts();
+  const [ref, isView] = useInView();
+
+  useEffect(() => {
+    if (authUserId === -1) {
+      return;
+    }
+
+    if (userId !== authUserId) {
+      router.push('/');
+      return;
+    }
+  }, [authUserId]);
+
+  useEffect(() => {
+    if (isView && hasNextPage) {
+      fetchNextPage();
+    }
+  }, [isView, productPages]);
+
+  if (authUserId === -1) {
+    return (
+      <Center height="100%">
+        <Spinner size="xl" />
+      </Center>
+    );
+  }
+
   return (
     <>
-      {/* @ TODO 실제 사용자 닉네임으로 교체 예정 */}
-      <SEO title="사용자 이름" />
+      <SEO title={`${username}의 판매한 상품`} />
       <Header
         leftContent={<GoBackIcon />}
         middleContent={<HeaderTitle title="찜한 상품" />}
       />
-      {DUMMY.length === 0 ? (
+      {productPages?.pages.map(({ data }, pageIndex) => {
+        return data.map((product, productIndex) => {
+          const lastPageIndex = productPages.pages.length - 1;
+          const lastProductIndex = data.length - 1;
+          const isLastProduct =
+            lastPageIndex === pageIndex && lastProductIndex === productIndex;
+          return isLastProduct ? (
+            <div ref={ref} key={product.id}>
+              <ProductCardContainer product={product} />
+            </div>
+          ) : (
+            <ProductCardContainer key={product.id} product={product} />
+          );
+        });
+      })}
+      {productPages?.pages[0].data.length === 0 && (
         <Center flexDirection="column" height="100%">
           <NoProducts pageName="userLikeProducts" />
         </Center>
-      ) : (
-        <Text>list of Product Cards</Text>
       )}
     </>
   );


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] 회원 정보 - 찜한 상품 페이지 API 연동
- [x] 회원 정보 - 찜한 상품 페이지 무한 스크롤 적용

# 작업 진행 사항
- 이전에 회원 정보 입찰 상품 페이지의 무한 스크롤 렌더링과 동일합니다.

# 관련 이슈
- 없습니다.

# 중점적으로 봐줬으면 하는 부분
- 이전 무한 스크롤과 거의 흡사한 코드입니다. 리팩토링 기간에 개선될 예정입니다.