### PR TITLE
[BM-366] 처음 채팅방 생성 시간 오류 수정과 임시 메세지 추가

### DIFF
--- a/components/User/ChattingCard.tsx
+++ b/components/User/ChattingCard.tsx
@@ -7,7 +7,7 @@ interface ChattingProps {
   profileImage: string;
   previewChat: string;
   productImage: string;
-  createdAt: Date;
+  createdAt: Date | null;
   onClick: () => void;
 }
 
@@ -34,7 +34,7 @@ const ChattingCard = ({
             <Text fontWeight="bold">{username}</Text>
             <Text fontSize="sm" color="brand.dark-light" paddingLeft="10px">
               {/* TODO: 채팅 내용 길어지면 '...' 표시해주기  */}
-              {distanceTimeFormat(createdAt)}
+              {createdAt ? distanceTimeFormat(createdAt) : ''}
             </Text>
           </Flex>
           <Text paddingTop="5px">{previewChat}</Text>

--- a/components/User/ChattingCard.tsx
+++ b/components/User/ChattingCard.tsx
@@ -5,7 +5,7 @@ import distanceTimeFormat from 'utils/format/distanceTimeFormat';
 interface ChattingProps {
   username: string;
   profileImage: string;
-  previewChat: string;
+  previewChat: string | null;
   productImage: string;
   createdAt: Date | null;
   onClick: () => void;
@@ -37,7 +37,13 @@ const ChattingCard = ({
               {createdAt ? distanceTimeFormat(createdAt) : ''}
             </Text>
           </Flex>
-          <Text paddingTop="5px">{previewChat}</Text>
+          {previewChat ? (
+            <Text paddingTop="5px">{previewChat}</Text>
+          ) : (
+            <Text paddingTop="5px" color="brand.primary-900">
+              채팅방이 연결 됐습니다.
+            </Text>
+          )}
         </Flex>
         {/* TODO: 채팅 읽지 않으면 Badge표시해주기 */}
         <Image

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -63,14 +63,7 @@ const useTempLoginUser = ({
     }
 
     handleAuthUser && handleAuthUser({ isAuthUser, authUser });
-  }, [
-    isAuthFinished,
-    isAuthUser,
-    setAuthUser,
-    handleAuthUser,
-    handleNotAuthUser,
-    authUser,
-  ]);
+  }, [isAuthFinished, isAuthUser, setAuthUser, authUser]);
 
   return { authUser, isAuthUser, isAuthFinished };
 };

--- a/pages/user/[userId]/chat/index.tsx
+++ b/pages/user/[userId]/chat/index.tsx
@@ -88,7 +88,11 @@ const Chats: NextPage = ({
                 profileImage={opponentUserInfo.profileImage}
                 previewChat={lastMessage}
                 productImage={productInfo.thumbnailImage}
-                createdAt={new Date(lastMessageDate)}
+                createdAt={
+                  lastMessage === null
+                    ? null
+                    : new Date(lastMessageDate as Date)
+                }
                 onClick={() =>
                   router.push(
                     {

--- a/types/chatRooms/index.ts
+++ b/types/chatRooms/index.ts
@@ -8,7 +8,7 @@ export interface ChatRoomData {
     username: string;
     profileImage: string;
   };
-  lastMessage: string;
+  lastMessage: string | null;
   lastMessageDate: Date | null;
 }
 

--- a/types/chatRooms/index.ts
+++ b/types/chatRooms/index.ts
@@ -9,7 +9,7 @@ export interface ChatRoomData {
     profileImage: string;
   };
   lastMessage: string;
-  lastMessageDate: Date;
+  lastMessageDate: Date | null;
 }
 
 export type ChatRoomResponseType = Array<ChatRoomData>;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- [x] lastMessageDate null 예외처리
- [x] handleAuthUser 계속 호출되는 오류 수정 
- [x] 채팅방 생성시 임시 문구 추가 

# 작업 진행 사항
<img width="338" alt="스크린샷 2022-08-16 오전 12 33 31" src="https://user-images.githubusercontent.com/16220817/184666309-42527a1e-f9f4-4a7d-98bb-05336c5aa493.png">

# 관련 이슈

일단 임의로 메인색상으로 메세지도 넣어봤습니다. 나중에 필요할 때 커스터마이징 하시면 좋을 것 같습니다.
`lastMessageDate === null` 로 타입추론이 될 것 같은데 안되서 `as Date` 로 넘기게 됐습니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.