### PR TITLE
[BM-385] 채팅방 재접속시 웹소켓 연결 안되는 오류 수정

### DIFF
--- a/hooks/useStomp.ts
+++ b/hooks/useStomp.ts
@@ -62,6 +62,8 @@ const useStomp = ({ chatRoomId, userInfo, setMessages }: UseStompProps) => {
     if (client !== null && client.connected) {
       client.deactivate();
     }
+
+    client = null;
   };
 
   const publish = useCallback(


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)

채팅방 재접속시 웹소켓 연결 안되는 오류 수정

# 작업 진행 사항
as-is
![2ca9965153631519](https://user-images.githubusercontent.com/16220817/188173366-1ce7569f-c8e7-469c-a096-de3cf2ea1e89.gif)

to-be

https://user-images.githubusercontent.com/16220817/188174285-883fa7a3-6f88-477d-8f80-0b0897164bd4.mov

- `disclose()`시 `client`를 `null`로 설정.
- 다시 `connect`시 `client`가 `null`이기 때문에 연결이 가능.

# 관련 이슈

채팅방 상단에 이름이 안보일 때도 있다고 해서 확인할 예정입니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.