### PR TITLE
[BM-375] 채팅방 채팅 메세지 위에 해당 날짜들 표시하기

### DIFF
--- a/components/ChatRoom/ChatDateBox.tsx
+++ b/components/ChatRoom/ChatDateBox.tsx
@@ -1,7 +1,10 @@
 import { Center, Text } from '@chakra-ui/react';
 
-// TODO: 메세지 날짜별로 구분하고 날짜를 prop으로 받기
-const ChatDateBox = () => {
+interface ChatDateBoxProps {
+  chatDate: string;
+}
+
+const ChatDateBox = ({ chatDate }: ChatDateBoxProps) => {
   return (
     <Center
       bgColor="brand.primary-100"
@@ -17,7 +20,7 @@ const ChatDateBox = () => {
         fontSize="13px"
         lineHeight="15px"
       >
-        2022년 8월 14일
+        {chatDate}
       </Text>
     </Center>
   );

--- a/hooks/useChatMessages.ts
+++ b/hooks/useChatMessages.ts
@@ -1,0 +1,49 @@
+import { useCallback, useState } from 'react';
+
+import { ChatMeesageResponseType, ChatMessageData } from 'types/chatMessages';
+import chatDateFormat from 'utils/format/chatDateFormat';
+
+export type ChatMessagesType = {
+  chatDate: string;
+  messages: ChatMeesageResponseType;
+};
+
+const useChatMessages = () => {
+  const map = new Map();
+  const [chatMessages, setChatMessages] = useState<ChatMessagesType[]>([]);
+
+  const setPrevMessagesFromApi = useCallback(
+    (messages: ChatMeesageResponseType) => {
+      messages.forEach((message) => {
+        const date = chatDateFormat(new Date(message.createdAt));
+        const prevMessages = map.get(date) || [];
+
+        map.set(date, [...prevMessages, message]);
+      });
+
+      setChatMessages(
+        [...map].map(([chatDate, messages]) => ({ chatDate, messages }))
+      );
+    },
+    []
+  );
+
+  const addMessage = useCallback((message: ChatMessageData) => {
+    const today = chatDateFormat(new Date());
+    const prevMessages = map.get(today) || [];
+
+    map.set(today, [...prevMessages, message]);
+
+    setChatMessages(
+      [...map].map(([chatDate, messages]) => ({ chatDate, messages }))
+    );
+  }, []);
+
+  return {
+    chatMessages,
+    setPrevMessagesFromApi,
+    addMessage,
+  };
+};
+
+export default useChatMessages;

--- a/hooks/useStomp.ts
+++ b/hooks/useStomp.ts
@@ -1,9 +1,9 @@
 import { Client } from '@stomp/stompjs';
 import getConfig from 'next/config';
-import { Dispatch, SetStateAction, useCallback } from 'react';
+import { useCallback } from 'react';
 import SockJS from 'sockjs-client';
 
-import { ChatMeesageResponseType } from 'types/chatMessages';
+import { ChatMessageData } from 'types/chatMessages';
 import { UserInfo } from 'types/user';
 
 const { publicRuntimeConfig } = getConfig();
@@ -12,10 +12,10 @@ let client: Client | null = null;
 export interface UseStompProps {
   chatRoomId: number;
   userInfo: UserInfo;
-  setMessages: Dispatch<SetStateAction<ChatMeesageResponseType>>;
+  addMessage: (message: ChatMessageData) => void;
 }
 
-const useStomp = ({ chatRoomId, userInfo, setMessages }: UseStompProps) => {
+const useStomp = ({ chatRoomId, userInfo, addMessage }: UseStompProps) => {
   const connect = () => {
     if (client !== null) {
       return;
@@ -46,12 +46,7 @@ const useStomp = ({ chatRoomId, userInfo, setMessages }: UseStompProps) => {
           return;
         }
 
-        if (message.body) {
-          setMessages((prevMessages) => [
-            ...prevMessages,
-            JSON.parse(message.body),
-          ]);
-        }
+        addMessage(JSON.parse(message.body));
       }
     );
 

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -4,13 +4,13 @@ import {
   InferGetServerSidePropsType,
   NextPage,
 } from 'next';
-import { useEffect, useRef, useState } from 'react';
+import { Fragment, useEffect, useRef } from 'react';
 
 import { userAPI } from 'apis';
 import { ChatDateBox, ChatInput, MessageList } from 'components/ChatRoom';
 import { GoBackIcon, Header, HeaderTitle } from 'components/common';
+import useChatMessages, { ChatMessagesType } from 'hooks/useChatMessages';
 import useStomp from 'hooks/useStomp';
-import { ChatMeesageResponseType } from 'types/chatMessages';
 
 export const getServerSideProps: GetServerSideProps = async ({
   query: { userId, chatRoomId, chattingUsername = '' },
@@ -37,7 +37,8 @@ const ChatRoom: NextPage = ({
   chatRoomId,
   chattingUsername,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
-  const [messages, setMessages] = useState<ChatMeesageResponseType>([]);
+  const { chatMessages, setPrevMessagesFromApi, addMessage } =
+    useChatMessages();
   const { connect, disConnect, publish } = useStomp({
     chatRoomId,
     userInfo: {
@@ -45,7 +46,7 @@ const ChatRoom: NextPage = ({
       username: user.username,
       profileImage: user.profileImage,
     },
-    setMessages,
+    addMessage,
   });
   const lastRef = useRef<HTMLDivElement>(null);
 
@@ -67,7 +68,9 @@ const ChatRoom: NextPage = ({
       })
     ).data;
 
-    setMessages([...chatMessages.reverse(), ...messages]);
+    const nextMessages = [...chatMessages.reverse()];
+
+    setPrevMessagesFromApi(nextMessages);
   };
 
   useEffect(() => {
@@ -79,7 +82,7 @@ const ChatRoom: NextPage = ({
       behavior: 'smooth',
       block: 'end',
     });
-  }, [lastRef, messages]);
+  }, [lastRef, chatMessages]);
 
   // TODO: ... 아이콘에 채팅방 나가기, 신고하기 기능
   return (
@@ -89,12 +92,16 @@ const ChatRoom: NextPage = ({
         middleContent={<HeaderTitle title={chattingUsername} />}
       />
       <Flex height="100%" flexDirection="column" gap="16px">
-        <Center>
-          <ChatDateBox />
-        </Center>
-        <Flex flexDirection="column" flexGrow="1">
-          <MessageList userId={user.id} messages={messages} />
-        </Flex>
+        {chatMessages.map(({ chatDate, messages }: ChatMessagesType, index) => (
+          <Fragment key={index}>
+            <Center>
+              <ChatDateBox chatDate={chatDate} />
+            </Center>
+            <Flex flexDirection="column" flexGrow="1">
+              <MessageList userId={user.id} messages={messages} />
+            </Flex>
+          </Fragment>
+        ))}
       </Flex>
       <Flex
         position="sticky"

--- a/pages/user/[userId]/chat/[chatRoomId]/index.tsx
+++ b/pages/user/[userId]/chat/[chatRoomId]/index.tsx
@@ -97,7 +97,7 @@ const ChatRoom: NextPage = ({
             <Center>
               <ChatDateBox chatDate={chatDate} />
             </Center>
-            <Flex flexDirection="column" flexGrow="1">
+            <Flex flexDirection="column">
               <MessageList userId={user.id} messages={messages} />
             </Flex>
           </Fragment>

--- a/utils/format/chatDateFormat.ts
+++ b/utils/format/chatDateFormat.ts
@@ -1,9 +1,6 @@
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
 
-/**
- *  2022년 9월 4일
- */
 const chatDateFormat = (createdAt: Date) =>
   format(new Date(createdAt), 'yyyy년 M월 d일', { locale: ko });
 

--- a/utils/format/chatDateFormat.ts
+++ b/utils/format/chatDateFormat.ts
@@ -1,0 +1,10 @@
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+
+/**
+ *  2022년 9월 4일
+ */
+const chatDateFormat = (createdAt: Date) =>
+  format(new Date(createdAt), 'yyyy년 M월 d일', { locale: ko });
+
+export default chatDateFormat;


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
날짜별로 채팅메세지 분류해서 각자 맨 위에 렌더링 해주기

# 작업 진행 사항
as-is
<img width="349" alt="스크린샷 2022-09-05 오전 12 21 47" src="https://user-images.githubusercontent.com/16220817/188321005-4d535049-7af7-4930-8967-94d714216118.png">
to-be
<img width="351" alt="스크린샷 2022-09-05 오전 12 22 25" src="https://user-images.githubusercontent.com/16220817/188321027-b957a61f-7cfb-4089-8abb-a7501d6ea2d9.png">
`reactStrictMode` 해제하고 스크린샷을 찍었습니다.

`useChatMessages` hook에서 날짜별로 필터링한 메세지를 반환해서 렌더링 하도록 구현했습니다.
`map`을 활용해서 `key` 값으로는 날짜, `value`에는 해당 날짜의 메세지를 배열로 담았습니다.
날짜가 변경되는 시점을 확인할 수가 없어서
채팅을 입력할 때 마다 현재 날짜의 `key`로 `map`에 저장한 후
갱신된 `map`을 기준으로 렌더링할 `ChatMessagesType` 배열을 반환 했습니다.

```js
export type ChatMessagesType = {
  chatDate: string;
  messages: ChatMeesageResponseType;
};
```

# 관련 이슈
- 관련 이슈는 아니지만 채팅창 우측 버튼에 전송 기능이 바인딩이 안되어 있어서 추가할 계획입니다.
- 무한 스크롤 적용 없이 우선 100개의 offset을 가져오고 있는데 해당 부분도 수정 예정입니다.

# 중점적으로 봐줬으면 하는 부분
현재 구조가 적절한지 봐주시면 감사하겠습니다.