### PR TITLE
[BM-386] 로그인 페이지 재진입시 로그인 버튼 렌더링 안되는 문제 수정

### DIFF
--- a/components/Login/GoogleLoginButton.tsx
+++ b/components/Login/GoogleLoginButton.tsx
@@ -1,8 +1,7 @@
 import { Box } from '@chakra-ui/react';
 import getConfig from 'next/config';
 import { useRouter } from 'next/router';
-import Script from 'next/script';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 
 const { publicRuntimeConfig } = getConfig();
 
@@ -15,15 +14,29 @@ const GoogleLoginButton = () => {
     router.push(publicRuntimeConfig.googleLoginUrl);
   };
 
+  useEffect(() => {
+    const GOOGLE_GSI_SCRIPT_URL = 'https://accounts.google.com/gsi/client';
+    const script = document.createElement('script');
+
+    script.src = GOOGLE_GSI_SCRIPT_URL;
+    script.async = true;
+    script.defer = true;
+
+    document.body.appendChild(script);
+
+    return () => {
+      document.body.removeChild(script);
+    };
+  }, []);
+
   return (
     <>
-      <Script src="https://accounts.google.com/gsi/client" async defer />
       <Box
         id="g_id_onload"
         className="g_id_signin"
         data-type="standard"
         data-size="large"
-        data-theme="filled_blue"
+        data-theme="outline"
         data-text="sign_in_with"
         data-shape="rectangular"
         data-logo_alignment="left"


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
로그인 페이지 재진입시 로그인 버튼 렌더링 안되는 문제 수정

# 작업 진행 사항
as-is
<img width="349" alt="스크린샷 2022-09-05 오전 10 38 38" src="https://user-images.githubusercontent.com/16220817/188343767-f09ed7d8-b012-49b3-909f-119379d1651a.png">

to-be

https://user-images.githubusercontent.com/16220817/188350092-7addc19e-870a-473f-9c44-866f510776e4.mov

# 관련 이슈
- 로그인 버튼 색상 변경 의견이 있어서 파란색을 제거했습니다.
- client-id를 등록 안해서 오류가 발생하는데 해결할 예정입니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.