### PR TITLE
[BM-387] 채팅메세지 버튼으로도 전송되도록 수정

### DIFF
--- a/components/ChatRoom/ChatInput.tsx
+++ b/components/ChatRoom/ChatInput.tsx
@@ -5,27 +5,30 @@ import {
   InputGroup,
   InputRightElement,
 } from '@chakra-ui/react';
+import { useState } from 'react';
 
 interface ChatInputProps {
   onSubmit: (nextMessage: string) => void;
 }
 
 const ChatInput = ({ onSubmit }: ChatInputProps) => {
+  const [chatMessage, setChatMessage] = useState('');
+  const sendChatMessage = () => {
+    onSubmit(chatMessage);
+    setChatMessage('');
+  };
   const handleKeyup = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
-      const target = e.target as HTMLInputElement;
-
-      onSubmit(target.value);
-      target.value = '';
+      sendChatMessage();
 
       return;
     }
   };
 
-  //TODO: Input 안에 IconButton클릭 시에도 채팅이 입력되도록 구현
   return (
     <InputGroup size="md">
       <Input
+        value={chatMessage}
         bgColor="#EFEFEF"
         border="0.7px solid #EFEFEF"
         borderRadius="30px"
@@ -40,6 +43,7 @@ const ChatInput = ({ onSubmit }: ChatInputProps) => {
         }}
         focusBorderColor="brand.primary-900"
         onKeyUp={handleKeyup}
+        onChange={(e) => setChatMessage(e.target.value)}
       />
       <InputRightElement width="4.5rem">
         <IconButton
@@ -48,6 +52,7 @@ const ChatInput = ({ onSubmit }: ChatInputProps) => {
           aria-label="arrow-icon"
           icon={<ArrowUpIcon />}
           backgroundColor="#EFEFEF"
+          onClick={sendChatMessage}
         />
       </InputRightElement>
     </InputGroup>


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
채팅메세지 버튼으로도 전송되도록 수정

# 작업 진행 사항
https://user-images.githubusercontent.com/16220817/189477295-153152d6-c970-4ac7-8e95-3e684920be32.mov

# 관련 이슈
버튼을 눌렀을 때 채팅메세지를 알고 있어야해서 `chatMessage` 상태를 추가해서 구현했습니다.

# 중점적으로 봐줬으면 하는 부분
없습니다.