### PR TITLE
[BM-388] 메인헤더 컴포넌트가 아닌 메인페이지에서 로딩 처리하도록 수정

### DIFF
--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import { Header } from 'components/common';
+import { EMPTY_USERID } from 'hooks/useLoginUser';
 import { User } from 'types/user';
 
 import LoginButton from './LoginButton';
@@ -26,7 +27,7 @@ const MainHeader = ({ authUser: { id, profileImage } }: MainHeaderProps) => {
       }
       // @TODO 컴포넌트로 분리 (BM-184 참고)
       rightContent={
-        id !== -1 ? (
+        id !== EMPTY_USERID ? (
           <Flex gap="10px" alignItems="center">
             <ChatIcon
               w="24px"

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -1,5 +1,6 @@
 import { BellIcon, ChatIcon } from '@chakra-ui/icons';
-import { Avatar, Circle, Flex, Image } from '@chakra-ui/react';
+import { Circle, Flex, Image as ChakraImage } from '@chakra-ui/react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import { Header } from 'components/common';
@@ -17,7 +18,7 @@ const MainHeader = ({ authUser: { id, profileImage } }: MainHeaderProps) => {
   return (
     <Header
       leftContent={
-        <Image
+        <ChakraImage
           src="/svg/bidmarket-logo.svg"
           alt="bidmarket logo"
           height="32px"
@@ -40,12 +41,21 @@ const MainHeader = ({ authUser: { id, profileImage } }: MainHeaderProps) => {
               onClick={() => router.push(`/user/${id}/notifications`)}
             />
             <Circle
+              position="relative"
+              minW="32px"
+              minH="32px"
               border="2px solid"
               borderColor="brand.primary-900"
+              overflow="hidden"
               _hover={{ cursor: 'pointer' }}
               onClick={() => router.push(`/user/${id}`)}
             >
-              <Avatar name="프로필 이미지" size="sm" src={profileImage} />
+              <Image
+                src={profileImage}
+                priority
+                alt="프로필 이미지"
+                layout="fill"
+              />
             </Circle>
           </Flex>
         ) : (

--- a/components/Main/MainHeader.tsx
+++ b/components/Main/MainHeader.tsx
@@ -1,28 +1,18 @@
 import { BellIcon, ChatIcon } from '@chakra-ui/icons';
 import { Avatar, Circle, Flex, Image } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
-import { useState } from 'react';
 
-import { Header, Loading } from 'components/common';
-import useLoginUser from 'hooks/useLoginUser';
+import { Header } from 'components/common';
+import { User } from 'types/user';
 
 import LoginButton from './LoginButton';
 
-const MainHeader = () => {
-  const router = useRouter();
-  const [isLogin, setIsLogin] = useState(false);
-  const {
-    isAuthFinished,
-    isAuthUser,
-    authUser: { id: userId, profileImage },
-  } = useLoginUser({
-    handleAuthUser: ({ isAuthUser }) => setIsLogin(isAuthUser),
-  });
+interface MainHeaderProps {
+  authUser: User;
+}
 
-  // TODO: 로딩은 메인 페이지에서 처리하도록 수정
-  if (!isAuthFinished || isAuthUser !== isLogin) {
-    return <Loading />;
-  }
+const MainHeader = ({ authUser: { id, profileImage } }: MainHeaderProps) => {
+  const router = useRouter();
 
   return (
     <Header
@@ -35,25 +25,25 @@ const MainHeader = () => {
       }
       // @TODO 컴포넌트로 분리 (BM-184 참고)
       rightContent={
-        isLogin ? (
+        id !== -1 ? (
           <Flex gap="10px" alignItems="center">
             <ChatIcon
               w="24px"
               h="24px"
               _hover={{ cursor: 'pointer' }}
-              onClick={() => router.push(`/user/${userId}/chat`)}
+              onClick={() => router.push(`/user/${id}/chat`)}
             />
             <BellIcon
               w="32px"
               h="32px"
               _hover={{ cursor: 'pointer' }}
-              onClick={() => router.push(`/user/${userId}/notifications`)}
+              onClick={() => router.push(`/user/${id}/notifications`)}
             />
             <Circle
               border="2px solid"
               borderColor="brand.primary-900"
               _hover={{ cursor: 'pointer' }}
-              onClick={() => router.push(`/user/${userId}`)}
+              onClick={() => router.push(`/user/${id}`)}
             >
               <Avatar name="프로필 이미지" size="sm" src={profileImage} />
             </Circle>

--- a/components/ProductDetail/ProductBid.tsx
+++ b/components/ProductDetail/ProductBid.tsx
@@ -16,6 +16,7 @@ import {
   ProductBidProgress,
   ProductBidRemainedTime,
 } from 'components/ProductDetail';
+import { EMPTY_USERID } from 'hooks/useLoginUser';
 import { priceFormat, setToastInfo } from 'utils';
 
 import ProductBidEndTextByStatus from './ProductBidEndTextByStatus';
@@ -179,7 +180,7 @@ const ProductBid = ({
       return;
     }
 
-    if (authUserId === -1) {
+    if (authUserId === EMPTY_USERID) {
       toast(
         setToastInfo('top', '입찰은 로그인 후 이용 가능합니다.', 'warning')
       );

--- a/components/ProductDetail/ProductHeart.tsx
+++ b/components/ProductDetail/ProductHeart.tsx
@@ -4,6 +4,7 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 
 import { heartAPI } from 'apis';
+import { EMPTY_USERID } from 'hooks/useLoginUser';
 import { setToastInfo } from 'utils';
 
 interface ProductHeartProps {
@@ -36,7 +37,7 @@ const ProductHeart = ({ productId, userId, title }: ProductHeartProps) => {
   };
 
   const checkLoginAuthUser = () => {
-    if (userId !== -1) {
+    if (userId !== EMPTY_USERID) {
       return;
     }
 

--- a/hooks/useLoginUser.ts
+++ b/hooks/useLoginUser.ts
@@ -14,6 +14,8 @@ interface UseLoginUserProps {
   handleNotAuthUser?: () => void;
 }
 
+export const EMPTY_USERID = -1;
+
 const useTempLoginUser = ({
   handleAuthUser,
   handleNotAuthUser,
@@ -21,7 +23,7 @@ const useTempLoginUser = ({
   const [isAuthFinished, setIsAuthFinished] = useState(false);
   const [isAuthUser, setIsAuthUser] = useState(false);
   const [authUser, setAuthUser] = useState<User>({
-    id: -1,
+    id: EMPTY_USERID,
     username: '',
     profileImage: '',
   });

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ const nextConfig = {
     stompUrl: `${process.env.STOMP_END_POINT}`,
     bucketUrl: `${process.env.BUCKET_URL}`,
   },
+  images: {
+    domains: ['lh3.googleusercontent.com'],
+  },
 };
 
 module.exports = nextConfig;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -5,8 +5,10 @@ import { useEffect, useState } from 'react';
 import { useInView } from 'react-intersection-observer';
 
 import { ProductCardContainer, SearchInput, SEO } from 'components/common';
+import Loading from 'components/common/Loading';
 import { Banner, MainHeader, ProductAddButton } from 'components/Main';
 import useGetInfiniteQuery from 'hooks/queries/useGetInfiniteQuery';
+import useLoginUser from 'hooks/useLoginUser';
 import { QUERY_KEYS } from 'utils';
 
 const Home: NextPage = () => {
@@ -18,6 +20,7 @@ const Home: NextPage = () => {
   const [ref, isView] = useInView();
   const router = useRouter();
   const [title, setTitle] = useState('');
+  const { isAuthFinished, authUser } = useLoginUser({});
 
   useEffect(() => {
     if (isView && hasNextPage) {
@@ -32,10 +35,14 @@ const Home: NextPage = () => {
     );
   };
 
+  if (!isAuthFinished) {
+    return <Loading />;
+  }
+
   return (
     <>
       <SEO title="비드마켓" />
-      <MainHeader />
+      <MainHeader authUser={authUser} />
       <Flex direction="column" width="100%">
         <Banner />
         <form onSubmit={handleFormSubmit}>


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
메인헤더 컴포넌트가 아닌 메인페이지에서 로딩 처리하도록 수정

# 작업 진행 사항

https://user-images.githubusercontent.com/16220817/189518397-0b0f7a8f-1d3c-4bac-bbb8-db9f0a07d823.mov

- 로딩 처리를 메인페이지에서 처리하도록 수정
- 프로필 이미지를 `chakra-ui Avatra`에서 `next/image`로 변경

# 관련 이슈
메인페이지에서 인증 정보 확인 후 렌더링 하도록 수정했으나 프로필 사진이 `프이`가 보인 후에 실제 프로필 사진이 보이게 렌더링 됨.
그래서 `next/image`의 `priority` 속성을 사용해서 프로필 이미지를 먼저 그려질 수 있도록 적용했습니다.
`next.config.js`에 해당 도메인이 등록이 필요한 부분이 있어서 해서 함께 수정했습니다.

# 중점적으로 봐줬으면 하는 부분
`next.config.js`의 `domain` 정보를 환경변수로 뺄 필요가 없다고 생각해서 바로 등록(url 주소를 하드코딩)했는데 다른 분들의 의견도 궁금합니다.
[참고 링크](https://jae04099.tistory.com/entry/ERROR-Error-Invalid-src-prop-on-nextimage)