### PR TITLE
[BM-389] 유저, 채팅, 알림, 채팅, 상품 상세, 신고하기 페이지 next/image로 개선

### DIFF
--- a/components/ChatRoom/RecievedMessage.tsx
+++ b/components/ChatRoom/RecievedMessage.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Box, Flex, Text } from '@chakra-ui/react';
+import { Box, Circle, Flex, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 
 import { UserInfo } from 'types/user';
 
@@ -17,11 +18,14 @@ const RecievedMessage = ({
 }: RecievedMessageProps) => {
   return (
     <Flex width="100%" justifyContent="flex-start" alignItems="center">
-      <Avatar
-        alignSelf="flex-start"
-        src={userInfo.profileImage}
-        marginRight="10px"
-      />
+      <Circle overflow="hidden" alignSelf="flex-start" marginRight="10px">
+        <Image
+          width="42px"
+          height="42px"
+          src={userInfo.profileImage}
+          alt="프로필이미지"
+        />
+      </Circle>
       <Flex
         alignSelf="flex-start"
         flexDirection="column"

--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -1,6 +1,7 @@
 import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
-import { Box, IconButton, Image, Progress } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
+import { Box, IconButton, Progress } from '@chakra-ui/react';
+import Image from 'next/image';
+import { useState } from 'react';
 
 import { Image as ImageType } from 'types/product';
 
@@ -14,15 +15,19 @@ const ProductImage = ({ images }: ProductImageProps) => {
   if (images.length === 1) {
     const { order, url } = images[0];
     return (
-      <Image
+      <Box
         key={order}
         display={order === showImage ? 'visible' : 'none'}
         width="100%"
         height="317px"
-        objectFit="cover"
-        alt="product-image"
-        src={url ?? '/svg/basket.svg'}
-      />
+      >
+        <Image
+          layout="fill"
+          objectFit="cover"
+          alt="product-image"
+          src={url ?? '/svg/basket.svg'}
+        />
+      </Box>
     );
   }
 
@@ -57,18 +62,22 @@ const ProductImage = ({ images }: ProductImageProps) => {
       <Box position="relative" w="100%" h="317px">
         {images.map(({ order, url }) => {
           return (
-            <Image
+            <Box
               key={order}
               position="absolute"
               zIndex={1}
               opacity={order === showImage ? '1' : '0'}
               width="100%"
               height="317px"
-              objectFit="cover"
-              alt="product-image"
-              src={url ?? '/svg/basket.svg'}
               transition="all ease 0.3s 0s"
-            />
+            >
+              <Image
+                layout="fill"
+                objectFit="cover"
+                alt="product-image"
+                src={url ?? '/svg/basket.svg'}
+              />
+            </Box>
           );
         })}
       </Box>

--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -75,7 +75,7 @@ const ProductImage = ({ images }: ProductImageProps) => {
                 layout="fill"
                 objectFit="cover"
                 alt="product-image"
-                src={url ?? '/svg/basket.svg'}
+                src={url}
               />
             </Box>
           );

--- a/components/ProductDetail/ProductSeller.tsx
+++ b/components/ProductDetail/ProductSeller.tsx
@@ -29,7 +29,7 @@ const ProductSeller = ({ userId, name, profileImage }: ProductSellerProps) => {
         >
           <Image
             alt="profile-image"
-            src={profileImage || '/svg/bidmarket-bibi.svg'}
+            src={profileImage}
             width="45px"
             height="45px"
           />

--- a/components/ProductDetail/ProductSeller.tsx
+++ b/components/ProductDetail/ProductSeller.tsx
@@ -1,4 +1,5 @@
-import { Flex, Box, Image, Text } from '@chakra-ui/react';
+import { Flex, Box, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 interface ProductSellerProps {
@@ -16,9 +17,7 @@ const ProductSeller = ({ userId, name, profileImage }: ProductSellerProps) => {
       onClick={() => router.push(`/user/${userId}`)}
     >
       <Flex alignItems="center">
-        <Image
-          alt="profile-image"
-          src={profileImage || '/svg/bidmarket-bibi.svg'}
+        <Box
           w="45px"
           h="45px"
           borderRadius="50%"
@@ -26,7 +25,15 @@ const ProductSeller = ({ userId, name, profileImage }: ProductSellerProps) => {
           marginBottom="14px"
           border="1px"
           borderColor="brand.primary-900"
-        />
+          overflow="hidden"
+        >
+          <Image
+            alt="profile-image"
+            src={profileImage || '/svg/bidmarket-bibi.svg'}
+            width="45px"
+            height="45px"
+          />
+        </Box>
         <Text fontWeight="bold" marginLeft="14px">
           {name === 'UnKnown' ? '알 수 없음' : name}
         </Text>

--- a/components/ProfileEdit/ProfileImage.tsx
+++ b/components/ProfileEdit/ProfileImage.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Box, Circle, Text } from '@chakra-ui/react';
+import { Box, Circle, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 
 interface ProfileImageProps {
   profileImageUrl: string;
@@ -15,7 +16,12 @@ const ProfileImage = ({ profileImageUrl, onClick }: ProfileImageProps) => (
     cursor="pointer"
     onClick={onClick}
   >
-    <Avatar name="profile-image" size="2xl" src={profileImageUrl} />
+    <Image
+      width="112px"
+      height="112px"
+      src={profileImageUrl}
+      alt="프로필이미지"
+    />
     <Box
       position="absolute"
       bottom="0"

--- a/components/ReportForm/ProductInfo.tsx
+++ b/components/ReportForm/ProductInfo.tsx
@@ -1,4 +1,5 @@
-import { Divider, Flex, Image, Text } from '@chakra-ui/react';
+import { Box, Divider, Flex, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 
 interface ProductInfoProps {
   productInfo: {
@@ -14,13 +15,9 @@ const ProductInfo = ({ productInfo }: ProductInfoProps) => {
 
   return (
     <Flex gap="15px" alignItems="center">
-      <Image
-        w="90px"
-        h="90px"
-        src={image}
-        alt={`${title}-image`}
-        borderRadius="7px"
-      />
+      <Box borderRadius="7px" overflow="hidden" w="90px" h="90px">
+        <Image width="90px" height="90px" src={image} alt={`${title}-image`} />
+      </Box>
       <Flex direction="column">
         <Text>{title}</Text>
         <Flex marginTop="5px" gap="10px">

--- a/components/ReportForm/UserInfo.tsx
+++ b/components/ReportForm/UserInfo.tsx
@@ -1,4 +1,4 @@
-import { Flex, Image, Text } from '@chakra-ui/react';
+import { Circle, Flex, Image, Text } from '@chakra-ui/react';
 
 interface UserInfoProps {
   userInfo: {
@@ -12,13 +12,14 @@ const UserInfo = ({ userInfo }: UserInfoProps) => {
 
   return (
     <Flex gap="15px" alignItems="center">
-      <Image
-        w="90px"
-        h="90px"
-        src={profileImage}
-        alt={`${username}-프로필-이미지`}
-        borderRadius="50%"
-      />
+      <Circle borderRadius="7px" overflow="hidden" w="90px" h="90px">
+        <Image
+          width="90px"
+          height="90px"
+          src={profileImage}
+          alt={`${username}-프로필-이미지`}
+        />
+      </Circle>
       <Text fontSize="lg">{username}</Text>
     </Flex>
   );

--- a/components/ReportForm/UserInfo.tsx
+++ b/components/ReportForm/UserInfo.tsx
@@ -12,7 +12,7 @@ const UserInfo = ({ userInfo }: UserInfoProps) => {
 
   return (
     <Flex gap="15px" alignItems="center">
-      <Circle borderRadius="7px" overflow="hidden" w="90px" h="90px">
+      <Circle overflow="hidden" maxW="90px" maxH="90px">
         <Image
           width="90px"
           height="90px"

--- a/components/User/ChattingCard.tsx
+++ b/components/User/ChattingCard.tsx
@@ -23,7 +23,7 @@ const ChattingCard = ({
   return (
     <Box cursor="pointer" width="100%" onClick={onClick}>
       <Flex width="100%" padding="15px 0">
-        <Circle position="relative" overflow="hidden" w="44px" h="44px">
+        <Circle position="relative" overflow="hidden" maxW="44px" maxH="44px">
           <Image
             width="44px"
             height="44px"

--- a/components/User/ChattingCard.tsx
+++ b/components/User/ChattingCard.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Image, Text } from '@chakra-ui/react';
+import { Box, Circle, Flex, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 
 import distanceTimeFormat from 'utils/format/distanceTimeFormat';
 
@@ -22,13 +23,14 @@ const ChattingCard = ({
   return (
     <Box cursor="pointer" width="100%" onClick={onClick}>
       <Flex width="100%" padding="15px 0">
-        <Image
-          src={profileImage}
-          alt="profile-image"
-          w="44px"
-          h="44px"
-          borderRadius="50%"
-        />
+        <Circle position="relative" overflow="hidden" w="44px" h="44px">
+          <Image
+            width="44px"
+            height="44px"
+            src={profileImage}
+            alt="profile-image"
+          />
+        </Circle>
         <Flex direction="column" width="100%" paddingLeft="10px">
           <Flex alignItems="center">
             <Text fontWeight="bold">{username}</Text>
@@ -46,16 +48,22 @@ const ChattingCard = ({
           )}
         </Flex>
         {/* TODO: 채팅 읽지 않으면 Badge표시해주기 */}
-        <Image
+        <Box
+          overflow="hidden"
+          borderRadius="7px"
+          marginLeft="15px"
+          minW="65px"
           w="65px"
           h="65px"
-          minWidth="65px"
-          src={productImage}
-          alt="product-image"
-          borderRadius="7px"
-          objectFit="cover"
-          marginLeft="15px"
-        />
+        >
+          <Image
+            width="65px"
+            height="65px"
+            src={productImage}
+            alt="product-image"
+            objectFit="cover"
+          />
+        </Box>
       </Flex>
     </Box>
   );

--- a/components/User/NotificationCard.tsx
+++ b/components/User/NotificationCard.tsx
@@ -1,4 +1,5 @@
-import { Box, Flex, Image, Text } from '@chakra-ui/react';
+import { Box, Flex, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 import { notificationAPI } from 'apis';
@@ -44,8 +45,8 @@ const NotificationCard = ({
         <Image
           src="/svg/bidProductMenuIcon.svg"
           alt="notification-icon"
-          w="44px"
-          h="44px"
+          width="44px"
+          height="44px"
         />
         <Flex width="100%" direction="column" paddingLeft="10px">
           <Text fontWeight="bold">{title}</Text>
@@ -58,16 +59,22 @@ const NotificationCard = ({
                 {distanceTimeFormat(new Date(createdAt))}
               </Text>
             </Flex>
-            <Image
+            <Box
               w="71px"
               h="71px"
-              minWidth="71px"
-              src={productImage}
-              alt="product-image"
+              minW="71px"
               borderRadius="7px"
-              objectFit="cover"
               marginLeft="15px"
-            />
+              overflow="hidden"
+            >
+              <Image
+                width="71px"
+                height="71px"
+                src={productImage}
+                alt="product-image"
+                objectFit="cover"
+              />
+            </Box>
           </Flex>
         </Flex>
       </Flex>

--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightIcon } from '@chakra-ui/icons';
-import { Flex, Divider, Text, Image } from '@chakra-ui/react';
+import { Flex, Divider, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 
 interface ProductMenuItemProps {

--- a/components/User/UserProfileInformation.tsx
+++ b/components/User/UserProfileInformation.tsx
@@ -1,4 +1,5 @@
-import { Avatar, Circle, Flex, Text } from '@chakra-ui/react';
+import { Circle, Flex, Text } from '@chakra-ui/react';
+import Image from 'next/image';
 
 interface UserInformationProps {
   profileImageUrl: string;
@@ -11,11 +12,16 @@ const UserProfileInformation = ({
 }: UserInformationProps) => {
   return (
     <Flex width="100%" gap="20px" alignItems="center" marginTop="12px">
-      <Circle border="2px solid" borderColor="brand.primary-900">
-        <Avatar
-          name="프로필 이미지"
-          size="xl"
-          src={profileImageUrl || '/svg/bidmarket-bibi.svg'}
+      <Circle
+        overflow="hidden"
+        border="2px solid"
+        borderColor="brand.primary-900"
+      >
+        <Image
+          width="84px"
+          height="84px"
+          src={profileImageUrl}
+          alt={`${nickname}-프로필이미지`}
         />
       </Circle>
       <Text

--- a/pages/login/index.tsx
+++ b/pages/login/index.tsx
@@ -1,5 +1,6 @@
-import { Flex, Image } from '@chakra-ui/react';
+import { Box, Flex } from '@chakra-ui/react';
 import type { NextPage } from 'next';
+import Image from 'next/image';
 
 import { Header, GoBackIcon, SEO, HeaderTitle } from 'components/common';
 import { GoogleLoginButton, Phrases } from 'components/Login';
@@ -14,12 +15,14 @@ const Login: NextPage = () => {
       />
       <Flex direction="column" alignItems="center" marginTop="50px">
         <Phrases />
-        <Image
-          src="/svg/bidmarket-login.svg"
-          alt="basket"
-          marginTop="20px"
-          marginBottom="45px"
-        />
+        <Box marginTop="20px" marginBottom="45px">
+          <Image
+            src="/svg/bidmarket-login.svg"
+            alt="basket"
+            width="131px"
+            height="131px"
+          />
+        </Box>
         <GoogleLoginButton />
       </Flex>
     </>

--- a/pages/products/[productId].tsx
+++ b/pages/products/[productId].tsx
@@ -1,6 +1,7 @@
-import { Divider, Flex, Box, Image } from '@chakra-ui/react';
+import { Divider, Flex, Box } from '@chakra-ui/react';
 import { format } from 'date-fns';
 import type { GetServerSideProps, InferGetServerSidePropsType } from 'next';
+import Image from 'next/image';
 import { useRouter } from 'next/router';
 import { useState } from 'react';
 
@@ -90,7 +91,12 @@ const ProductDetail = ({
         onClick={handleReportSirenIconClick}
       >
         {!isSeller && (
-          <Image src="/svg/siren-light.svg" alt="siren-light-icon" />
+          <Image
+            src="/svg/siren-light.svg"
+            alt="siren-light-icon"
+            width="25px"
+            height="25px"
+          />
         )}
       </Box>
       <Flex direction="column" width="100%" marginTop="317px">


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
chakra-ui에서 image태그를 가져오는 부분 중 남은 부분을 next/image를 사용하도록 개선하였습니다.


# 작업 진행 사항
아래 이미지들을 모두 next/image로 개선하였습니다.
```
- 신고하기 유저/상품 이미지
- 상세 상품 판매자 이미지
- 상세 상품 이미지
- 채팅 유저 이미지
- 알림 리스트 상품 이미지
- 채팅 리스트 유저 프로필, 상품 이미지
- 유저 프로필, 프로필 수정 이미지
```
[PR-86](https://github.com/prgrms-web-devcourse/Team-Saiko-BidMarket-FE/pull/86)에 이미지 개선 속도 개선 내용 적어두었습니다!

# 관련 이슈
- 없습니다!

# 중점적으로 봐줬으면 하는 부분
- next/image로 더 적용할 부분 있는지 확인 부탁드리겠습니다!