### PR TITLE
[BM-390] 링크 태그로 변경된 레이아웃 재적용

### DIFF
--- a/components/User/ProductMenuItem.tsx
+++ b/components/User/ProductMenuItem.tsx
@@ -16,37 +16,39 @@ const ProductMenuItem = ({
   isLastItem,
 }: ProductMenuItemProps) => {
   return (
-    <Link href={routingUrl} passHref>
-      <a>
-        <Flex
-          width="100%"
-          justifyContent="space-between"
-          alignItems="center"
-          gap="13px"
-          cursor="pointer"
-        >
-          <Flex justifyContent="space-between" alignItems="center" gap="10px">
-            <Image
-              width="33.92px"
-              height="38px"
-              src={iconUrl}
-              alt={`${title} 아이콘`}
-            />
-            <Text
-              color="brand.dark"
-              fontFamily="Roboto"
-              fontStyle="normal"
-              fontSize="16px"
-              lineHeight="128.19%"
-            >
-              {title}
-            </Text>
+    <>
+      <Link href={routingUrl} passHref>
+        <a>
+          <Flex
+            width="100%"
+            justifyContent="space-between"
+            alignItems="center"
+            gap="13px"
+            cursor="pointer"
+          >
+            <Flex justifyContent="space-between" alignItems="center" gap="10px">
+              <Image
+                width="33.92px"
+                height="38px"
+                src={iconUrl}
+                alt={`${title} 아이콘`}
+              />
+              <Text
+                color="brand.dark"
+                fontFamily="Roboto"
+                fontStyle="normal"
+                fontSize="16px"
+                lineHeight="128.19%"
+              >
+                {title}
+              </Text>
+            </Flex>
+            <ChevronRightIcon />
           </Flex>
-          <ChevronRightIcon />
-        </Flex>
-        {!isLastItem && <Divider />}
-      </a>
-    </Link>
+        </a>
+      </Link>
+      {!isLastItem && <Divider />}
+    </>
   );
 };
 

--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -16,70 +16,72 @@ const ProductCard = ({ productInfo }: ProductCardProps) => {
     productInfo;
 
   return (
-    <Link href={`/products/${id}`} passHref>
-      <a>
-        <Flex padding="15px 0" w="100%" h="144px" cursor="pointer">
-          <Box>
-            <ProductCardImage
-              alt={`${id}-product-image`}
-              src={thumbnailImage}
-            />
-          </Box>
-          <Flex
-            direction="column"
-            paddingLeft="15px"
-            w="100%"
-            gap="5px"
-            overflow="hidden"
-          >
-            <Text
-              fontSize="lg"
-              whiteSpace="nowrap"
+    <Box w="100%">
+      <Link href={`/products/${id}`} passHref>
+        <a>
+          <Flex padding="15px 0" w="100%" h="144px" cursor="pointer">
+            <Box>
+              <ProductCardImage
+                alt={`${id}-product-image`}
+                src={thumbnailImage}
+              />
+            </Box>
+            <Flex
+              direction="column"
+              paddingLeft="15px"
+              w="100%"
+              gap="5px"
               overflow="hidden"
-              textOverflow="ellipsis"
             >
-              {title}
-            </Text>
-            <Flex justifyContent="space-between" alignItems="center">
-              <Text fontSize="sm" color="brand.primary-900">
-                시작가
-              </Text>
               <Text
-                fontSize="sm"
-                bg="brand.primary-100"
-                color="brand.primary-900"
-                padding="3px 10px"
-                borderRadius="20px"
-                fontWeight="bold"
+                fontSize="lg"
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
               >
-                {priceFormat(minimumPrice)}원
+                {title}
               </Text>
-            </Flex>
-            <Flex justifyContent="space-between" alignItems="center">
-              <Text fontSize="sm">남은 시간</Text>
-              <Text
-                fontSize="sm"
-                bg="#EFEFEF"
-                padding="3px 10px"
-                borderRadius="20px"
-              >
-                {remainedTimeFormat(expireAt) === ''
-                  ? '0분'
-                  : remainedTimeFormat(expireAt)}
-              </Text>
-            </Flex>
-            <Flex justifyContent="flex-end" alignItems="center">
-              <StarIcon color="#BFBFBF" w="3" />
-              <Text fontSize="xs" marginLeft="5px" paddingRight="5px">
-                {heartCount
-                  ? `${heartCount}명이 이 상품을 찜했어요!`
-                  : `아직 아무도 찜하지 않았어요!`}
-              </Text>
+              <Flex justifyContent="space-between" alignItems="center">
+                <Text fontSize="sm" color="brand.primary-900">
+                  시작가
+                </Text>
+                <Text
+                  fontSize="sm"
+                  bg="brand.primary-100"
+                  color="brand.primary-900"
+                  padding="3px 10px"
+                  borderRadius="20px"
+                  fontWeight="bold"
+                >
+                  {priceFormat(minimumPrice)}원
+                </Text>
+              </Flex>
+              <Flex justifyContent="space-between" alignItems="center">
+                <Text fontSize="sm">남은 시간</Text>
+                <Text
+                  fontSize="sm"
+                  bg="#EFEFEF"
+                  padding="3px 10px"
+                  borderRadius="20px"
+                >
+                  {remainedTimeFormat(expireAt) === ''
+                    ? '0분'
+                    : remainedTimeFormat(expireAt)}
+                </Text>
+              </Flex>
+              <Flex justifyContent="flex-end" alignItems="center">
+                <StarIcon color="#BFBFBF" w="3" />
+                <Text fontSize="xs" marginLeft="5px" paddingRight="5px">
+                  {heartCount
+                    ? `${heartCount}명이 이 상품을 찜했어요!`
+                    : `아직 아무도 찜하지 않았어요!`}
+                </Text>
+              </Flex>
             </Flex>
           </Flex>
-        </Flex>
-      </a>
-    </Link>
+        </a>
+      </Link>
+    </Box>
   );
 };
 


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- 링크 태그 추가로 변경된 레이아웃 재적용

# 작업 진행 사항
![image](https://user-images.githubusercontent.com/50071076/192337445-e0ac5b53-168f-4387-9ac9-abc94d0a44f4.png)
![image](https://user-images.githubusercontent.com/50071076/192337511-83c8dee1-6c61-45df-b03f-6f3be23ae314.png)

`<Link>`태그 추가 시 레이아웃이 제대로 적용되지 않았던 점을 확인하지 못하였었습니다.ㅠㅠ
위 두 페이지 다시 레이아웃 적용해서 올립니다!

# 관련 이슈
없습니다

# 중점적으로 봐줬으면 하는 부분
없습니다
