### PR TITLE
[BM-391] App.js에 Loading 추가(상세페이지 로딩 적용)

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,7 +2,10 @@ import { ChakraProvider, extendTheme } from '@chakra-ui/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import type { AppProps } from 'next/app';
+import { Router } from 'next/router';
+import { useEffect, useState } from 'react';
 
+import { Loading } from 'components/common';
 import Layout from 'components/Layout';
 
 const theme = extendTheme({
@@ -20,11 +23,32 @@ const theme = extendTheme({
 const queryClient = new QueryClient();
 
 function MyApp({ Component, pageProps }: AppProps) {
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const startLoading = () => {
+      setIsLoading(true);
+    };
+
+    const finishedLoading = () => {
+      setIsLoading(false);
+
+    Router.events.on('routeChangeStart', startLoading);
+    Router.events.on('routeChangeComplete', finishedLoading);
+    Router.events.on('routeChangeError', finishedLoading);
+
+    return () => {
+      Router.events.off('routeChangeStart', startLoading);
+      Router.events.off('routeChangeComplete', finishedLoading);
+      Router.events.off('routeChangeError', finishedLoading);
+    };
+  }, []);
+
   return (
     <QueryClientProvider client={queryClient}>
       <ChakraProvider theme={theme}>
         <Layout>
-          <Component {...pageProps} />
+          {isLoading ? <Loading /> : <Component {...pageProps} />}
         </Layout>
       </ChakraProvider>
       <ReactQueryDevtools initialIsOpen={false} />

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,6 +32,7 @@ function MyApp({ Component, pageProps }: AppProps) {
 
     const finishedLoading = () => {
       setIsLoading(false);
+    };
 
     Router.events.on('routeChangeStart', startLoading);
     Router.events.on('routeChangeComplete', finishedLoading);


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- App.js에 Loading 추가

# 작업 진행 사항
상품 카드를 누르고 상세페이지로 이동하는 과정을 SSR을 구현하면서 로딩 처리가 안되어 있어서 사용자 경험이 안좋았던 부분이 있었습니다.

getServerSideProps로 데이터를 가져오기 때문에 로딩 로직을 구현하려면 app.js에서 구현해야합니다. 

```js
routeChangeStart(url, { shallow }) - 라우트가 변경되기 시작할때 트리거 됩니다
routeChangeComplete(url, { shallow }) - 라우트가 완전히 변경되었을 때 트리거 됩니다
routeChangeError(err, url, { shallow }) - 라우트 변경 중에 에러가 발생했거나, 취소되었을 때 트리거 됩니다
```
위의 Router 이벤트로 페이지 간의 로딩을 구현하였습니다.

참고자료
- [Loading Screen on next js page transition](https://stackoverflow.com/questions/55624695/loading-screen-on-next-js-page-transition)
- [Next.js getServerSideProps loading state](https://stackoverflow.com/questions/69263469/next-js-getserversideprops-loading-state)

### 상세 페이지 로딩 적용
![상세페이지로딩](https://user-images.githubusercontent.com/50071076/193247747-ab823e12-2cde-4a5c-9814-9d602d458080.gif)



# 관련 이슈
- chakra-ui의 아래 theme 부분 utils로 빼면 좋을 것 같아요
```js
const theme = extendTheme({
  colors: {
    brand: {
      'primary-900': '#FF4370',
      'primary-500': '#FFDEE6',
      'primary-100': '#FFECF2',
      dark: '#2E2E2E',
      'dark-light': '#8E8E8E',
    },
  },
});
```

# 중점적으로 봐줬으면 하는 부분
없습니다! 궁금한 점 질문 해주시면 감사하겠습니다