### PR TITLE
[BM-393] 상품 상세 메인 이미지, 상품 카드 이미지 blur 적용

### DIFF
--- a/components/ProductDetail/ProductImage.tsx
+++ b/components/ProductDetail/ProductImage.tsx
@@ -10,6 +10,9 @@ interface ProductImageProps {
   images: ImageType[];
 }
 
+const BLUR_DATA_URL =
+  'data:image/jpeg;base64, iVBORw0KGgoAAAANSUhEUgAAAfQAAAAfCAYAAAARIj9/AAAAfUlEQVR42u3VQQ0AAAgEIE1usXsYzRxuUILOZgoAeK2FDgBCBwCEDgAIHQAQOgAIHQAQOgAgdABA6AAgdABA6ACA0AEAoQOA0AEAoQMAQgcAhA4AQgcAhA4ACB0AEDoACB0AEDoAIHQAQOgAIHQAQOgAgNABAKEDgNABgFcOAXxUSX5JIaEAAAAASUVORK5CYII=';
+
 const ProductImage = ({ images }: ProductImageProps) => {
   const [showImage, setShowImage] = useState(1);
 
@@ -27,6 +30,8 @@ const ProductImage = ({ images }: ProductImageProps) => {
           objectFit="cover"
           alt="product-image"
           src={url ?? SVG_URL.BASKET}
+          placeholder="blur"
+          blurDataURL={BLUR_DATA_URL}
         />
       </Box>
     );
@@ -77,6 +82,8 @@ const ProductImage = ({ images }: ProductImageProps) => {
                 objectFit="cover"
                 alt="product-image"
                 src={url}
+                placeholder="blur"
+                blurDataURL={BLUR_DATA_URL}
               />
             </Box>
           );

--- a/components/common/ProductCard/ProductCardImage.tsx
+++ b/components/common/ProductCard/ProductCardImage.tsx
@@ -16,6 +16,8 @@ const CardProductImage = ({ alt, src }: CardProductImageProps) => {
         height={114}
         alt={alt}
         src={src}
+        placeholder="blur"
+        blurDataURL="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAHIAAAByCAYAAACP3YV9AAAAuElEQVR42u3RMQkAAAgAME1uC8G2VvAVtgrL6angvRQpEpGIRKRIRCISkSIRiUhEIlIkIhGJSJGIRCQiRSISkYhEpEhEIhKRIhGJSESKFCkSkYhEpEhEIhKRIhGJSEQiUiQiEYlIkYhEJCJFIhKRiESkSEQiEpEiEYlIRIoUKRKRiESkSEQiEpEiEYlIRCJSJCIRiUiRiEQkIkUiEpGIRKRIRCISkSIRiUhEihQpEpGIRKRIRCKSqwXv2AQgpeMeOQAAAABJRU5ErkJggg=="
       />
     </Box>
   );

--- a/components/common/ProductCard/ProductCardImage.tsx
+++ b/components/common/ProductCard/ProductCardImage.tsx
@@ -6,6 +6,9 @@ interface CardProductImageProps {
   src: string;
 }
 
+const BLUR_DATA_URL =
+  'data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAHIAAAByCAYAAACP3YV9AAAAuElEQVR42u3RMQkAAAgAME1uC8G2VvAVtgrL6angvRQpEpGIRKRIRCISkSIRiUhEIlIkIhGJSJGIRCQiRSISkYhEpEhEIhKRIhGJSESKFCkSkYhEpEhEIhKRIhGJSEQiUiQiEYlIkYhEJCJFIhKRiESkSEQiEpEiEYlIRIoUKRKRiESkSEQiEpEiEYlIRCJSJCIRiUiRiEQkIkUiEpGIRKRIRCISkSIRiUhEihQpEpGIRKRIRCKSqwXv2AQgpeMeOQAAAABJRU5ErkJggg==';
+
 const CardProductImage = ({ alt, src }: CardProductImageProps) => {
   return (
     <Box borderRadius={'5px'} overflow="hidden" w="114px" h="114px">
@@ -17,7 +20,7 @@ const CardProductImage = ({ alt, src }: CardProductImageProps) => {
         alt={alt}
         src={src}
         placeholder="blur"
-        blurDataURL="data:image/jpeg;base64,iVBORw0KGgoAAAANSUhEUgAAAHIAAAByCAYAAACP3YV9AAAAuElEQVR42u3RMQkAAAgAME1uC8G2VvAVtgrL6angvRQpEpGIRKRIRCISkSIRiUhEIlIkIhGJSJGIRCQiRSISkYhEpEhEIhKRIhGJSESKFCkSkYhEpEhEIhKRIhGJSEQiUiQiEYlIkYhEJCJFIhKRiESkSEQiEpEiEYlIRIoUKRKRiESkSEQiEpEiEYlIRCJSJCIRiUiRiEQkIkUiEpGIRKRIRCISkSIRiUhEihQpEpGIRKRIRCKSqwXv2AQgpeMeOQAAAABJRU5ErkJggg=="
+        blurDataURL={BLUR_DATA_URL}
       />
     </Box>
   );


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- 상품 상세 메인 이미지, 상품 카드 이미지 blur 적용

# 작업 진행 사항
[참고 링크입니다](https://velog.io/@sangbooom/next.js-%EC%9D%B4%EB%AF%B8%EC%A7%80-%EC%8A%A4%EC%BC%88%EB%A0%88%ED%86%A4-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0)
새로고침 했을 경우 다음과 같이 적용 되는 것을 확인

### 상품 카드 이미지 blur 적용
![메인페이지 placeholder](https://user-images.githubusercontent.com/50071076/195280538-32369646-6fe7-4c88-9dfe-61e55ba2a196.gif)

### 상세 이미지 blur 적용
![상품 상세 이미지 placeholder](https://user-images.githubusercontent.com/50071076/195288916-eb9d4536-94fa-462f-a21a-a1b543f1f375.gif)


# 관련 이슈
<!-- TODO, 테스트 유의, 앞으로 구현해야할 기능 -->
- 없었습니다


# 중점적으로 봐줬으면 하는 부분
우선 상품 카드, 상세 이미지 부분만 적용시켰는데 다른 부분 적용이 필요할까요? 여러분 생각이 궁금합니다