### PR TITLE
[BM-394] 검색 페이지 무한 렌더링 버그 수정

### DIFF
--- a/components/common/ProductCard/index.tsx
+++ b/components/common/ProductCard/index.tsx
@@ -3,7 +3,7 @@ import { Box, Flex, Text } from '@chakra-ui/react';
 import Link from 'next/link';
 
 import { CardProductData } from 'types/product';
-import { priceFormat, remainedTimeFormat, SVG_URL } from 'utils';
+import { priceFormat, remainedTimeFormat } from 'utils';
 
 import ProductCardImage from './ProductCardImage';
 

--- a/pages/auth/index.tsx
+++ b/pages/auth/index.tsx
@@ -1,4 +1,3 @@
-import { Center, Spinner } from '@chakra-ui/react';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -26,13 +26,11 @@ const Home: NextPage = () => {
     if (isView && hasNextPage) {
       fetchNextPage();
     }
-  }, [isView, productPages]);
+  }, [isView, productPages, fetchNextPage, hasNextPage]);
 
   const handleFormSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    router.push(
-      `/products?title=${title}&sort=END_DATE_ASC&category=ALL&progressed=true&offset=0&limit=10`
-    );
+    router.push(`/products?title=${title}`);
   };
 
   if (!isAuthFinished) {
@@ -48,7 +46,6 @@ const Home: NextPage = () => {
         <form onSubmit={handleFormSubmit}>
           <SearchInput keyword={title} onChange={setTitle} />
         </form>
-        {/* @TODO 컴포넌트로 분리해보기 */}
         {productPages?.pages.map(({ data }, pageIndex) => {
           return data.map((product, productIndex) => {
             const lastPageIndex = productPages.pages.length - 1;

--- a/pages/products/index.tsx
+++ b/pages/products/index.tsx
@@ -23,18 +23,21 @@ export const getServerSideProps: GetServerSideProps = async ({ query }) => {
   return { props: { queryDatas: query } };
 };
 
+const initialSortOption = 'END_DATE_ASC';
+const initialCategoryOption = 'ALL';
+const initialProgressedOption = true;
+
 const Products = ({
-  queryDatas,
+  queryDatas: { title },
 }: InferGetServerSidePropsType<typeof getServerSideProps>) => {
   const router = useRouter();
-  const { title, sort, category, progressed } = queryDatas;
   const [keyword, setKeyword] = useState<string>(title);
   const [selectedSortOption, setSelectedSortOption] =
-    useState<sortOptionsENType>(sort as sortOptionsENType);
+    useState<sortOptionsENType>(initialSortOption);
   const [selectedCategoryOption, setSelectedCategoryOption] =
-    useState<categoryOptionsENType>(category as categoryOptionsENType);
+    useState<categoryOptionsENType>(initialCategoryOption);
   const [isProgressed, setIsProgressed] = useState<boolean>(
-    Boolean(JSON.parse(progressed))
+    initialProgressedOption
   );
 
   // @TODO 쿼리스트링이 누락된 경우 메인페이지로 이동하는 예외처리
@@ -55,24 +58,15 @@ const Products = ({
     if (isView && hasNextPage) {
       fetchNextPage();
     }
-  }, [isView, productPages]);
-
-  useEffect(() => {
-    // @TODO router 주소 분리 작업 (for 가독성)
-    router.push(
-      `/products?title=${keyword}&sort=${selectedSortOption}&category=${selectedCategoryOption}&progressed=${isProgressed}&offset=0&limit=10`
-    );
-  }, [selectedSortOption, selectedCategoryOption, isProgressed]);
+  }, [isView, productPages, fetchNextPage, hasNextPage]);
 
   useEffect(() => {
     refetch();
-  }, [router.asPath]);
+  }, [selectedSortOption, selectedCategoryOption, isProgressed, refetch]);
 
   const handleFormSubmit = (event: React.FormEvent) => {
     event.preventDefault();
-    router.push(
-      `/products?title=${keyword}&sort=${selectedSortOption}&category=${selectedCategoryOption}&progressed=${isProgressed}&offset=0&limit=10`
-    );
+    router.push(`/products?title=${keyword}`);
   };
 
   // @TODO FilterButton과 함께 간결한 코드로 풀어낼 필요 (with Type)


### PR DESCRIPTION
# 🧑‍💻 작업 내용(개요)
- 검색 페이지에서 무한적으로 로딩과 결과를 번갈아 렌더링하는 이슈

<br>

# 작업 진행 사항
- 사용자의 검색 및 필터링에 따라 url을 동기화 할 수 있도록 router를 갱신하도록 하였습니다.
하지만 `_app.tsx`에 있는 router event가 route의 변동이 있을 때마다 실행하게 됩니다.
- 따라서 검색 페이지에 진입하게 되면 다음과 같은 무한 렌더링에 빠지게 됩니다.
   1. `routeChangeStart`이벤트 실행 -> `routeChangeComplete` 이벤트 실행
   2. 컴포넌트(검색 페이지) 렌더링 완료
   3. useEffect 실행 -> useEffect에 있는 router.push 실행 -> router 변화 감지 (Url은 동일하지만 push메서드로 인해)
   4. 다시 `routeChangeStart`, `routerChangeComplete` 이벤트 실행
   5. 컴포넌트(검색 페이지) 재렌더링
   6. ...무한 반복

- 이러한 이슈를 해결하기 위해 다음과 같은 고민을 하였습니다.
   - `useEffect` 와 `router.push` 로직 분리
      - 해당 이슈의 주요 원인으로 useEffect와 로직을 분리하려 시도.
      각 필터링 컴포넌트에 이벤트를 실행하면 가능하지만 로직이 더 복잡해져서 다른 방법을 고안.
   - (선택한 해결방법) 상태에 따른 상품 목록 렌더링은 가능하니, url에 있는 옵션 관련 쿼리스트링을 제거
      - url을 복사하여 전달하는 경우, 필터링 조건까지 모두 url에 담을 수 없다는 단점을 제외하고 최대한 로직을 건드리지 않고 해결 가능
      - 동일한 구조로 된 레퍼런스 (url 변동없이 무한스크롤 하는 사이트)
         - [유튜브](https://www.youtube.com/results?search_query=Lofi)
         - [원티드 이벤트](https://www.wanted.co.kr/events)

> 그 외 작은 작업으로 아래 두가지를 하였습니다.
> useEffect의 의존성 배열에 빠진 함수 및 변수를 작성해두었습니다. (_app.tsx 제외)
> 미사용, 불필요한 코드를 제거하였습니다.

<br>

# 관련 이슈
- 직접 테스트해보았지만, 또 다른 이슈를 찾게 되신다면 커멘트 꼭 부탁드립니다.

<br>

# 중점적으로 봐줬으면 하는 부분
- 현재 PR과는 무관내용이지만 `_app.tsx`에서 `import { Router } from 'next/router'` 에 다음과 같은 의문점이 남습니다.
   - #91 에서 참고하신 코드에 의하면 `import Router from 'next/router'`인데 구조 분해 할당으로 가져오신 부분이 궁금합니다.
   - 공식문에서 제안하는 예시코드에서는 `import { useRouter } from 'next/router'` 로 가져와서 사용합니다.
   동일하게 작동하지만 공식문서에서 제안하는 예시코드와 동일하게 하는 건 어떠신지 궁금합니다!
      - [공식문서 router.events](https://nextjs.org/docs/api-reference/next/router#routerevents)
      - [예시코드로 바로가기](https://github.com/vercel/next.js/blob/canary/examples/with-loading/pages/_app.tsx)